### PR TITLE
feat: add word diff mode

### DIFF
--- a/components/TextCompare.tsx
+++ b/components/TextCompare.tsx
@@ -44,6 +44,8 @@ const formatOptions = [
 
 const diffModes: { value: DiffMode; label: string }[] = [
   { value: 'lines', label: 'Lines' },
+  { value: 'words', label: 'Words' },
+  { value: 'sentences', label: 'Sentences' },
   { value: 'chars', label: 'Characters' },
 ];
 

--- a/utils/diff.ts
+++ b/utils/diff.ts
@@ -38,19 +38,35 @@ export function computeDiff(
     processedText2 = processedText2.replace(/\s+/g, ' ').trim();
   }
 
+  // Compute detailed changes based on selected mode
+  let changes: Diff.Change[];
+  switch (options.mode) {
+    case 'chars':
+      changes = Diff.diffChars(processedText1, processedText2);
+      break;
+    case 'words':
+      changes = Diff.diffWords(processedText1, processedText2);
+      break;
+    case 'sentences':
+      changes = Diff.diffSentences(processedText1, processedText2);
+      break;
+    default:
+      changes = Diff.diffLines(processedText1, processedText2);
+  }
+
   // Always use line diff for statistics
-  const changes = Diff.diffLines(processedText1, processedText2);
+  const lineChanges = Diff.diffLines(processedText1, processedText2);
 
   let addedLines = 0;
   let removedLines = 0;
   let identicalLines = 0;
   let modifiedLines = 0;
 
-  changes.forEach((change) => {
-    const lines = change.value.split('\n').filter((line, index, arr) => 
+  lineChanges.forEach((change) => {
+    const lines = change.value.split('\n').filter((line, index, arr) =>
       index < arr.length - 1 || line !== ''
     );
-    
+
     if (change.added) {
       addedLines += lines.length;
     } else if (change.removed) {
@@ -63,7 +79,7 @@ export function computeDiff(
   // Count modifications as the minimum of added and removed lines
   // This represents lines that were changed (not purely added or removed)
   modifiedLines = Math.min(addedLines, removedLines);
-  
+
   // Total represents unique diff locations
   const total = addedLines + removedLines - modifiedLines;
 


### PR DESCRIPTION
## Summary
- allow selecting "Words" and "Sentences" comparison modes
- compute diffs based on chosen mode while keeping line-based statistics

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_689a1bd9d0148328a4d9072bd135d20c