### PR TITLE
Redesign UI with editorial ink-and-paper aesthetic and fix diff alignment

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,46 +2,53 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ------------------------------------------------------------------ */
+/*  Design tokens — “ink & paper” editorial palette                    */
+/*  Warm ivory paper in light mode, deep warm charcoal in dark mode.   */
+/*  Rose = removed / original, teal = added / modified, everywhere.    */
+/* ------------------------------------------------------------------ */
+
 :root {
-  --background: #f8fafc;
-  --foreground: #0f172a;
-  --card: #ffffff;
-  --card-foreground: #0f172a;
-  --primary: #3b82f6;
-  --primary-foreground: #ffffff;
-  --secondary: #f1f5f9;
-  --secondary-foreground: #0f172a;
-  --muted: #f1f5f9;
-  --muted-foreground: #64748b;
-  --accent: #f1f5f9;
-  --accent-foreground: #0f172a;
-  --destructive: #ef4444;
-  --destructive-foreground: #ffffff;
-  --border: #e2e8f0;
-  --input: #e2e8f0;
-  --ring: #3b82f6;
-  --radius: 0.75rem;
+  --background: #f6f3ec;
+  --background-2: #ece7db;
+  --foreground: #211e19;
+  --surface: rgba(255, 254, 250, 0.72);
+  --sheet: #fffefa;
+  --ink: #1c1917;
+  --ink-soft: #57534e;
+  --muted-foreground: #8a8273;
+  --hairline: rgba(33, 30, 25, 0.1);
+  --hairline-strong: rgba(33, 30, 25, 0.22);
+  --primary: #1c1917;
+  --primary-foreground: #f8f6f0;
+  --added: #0d9488;
+  --added-strong: #0f766e;
+  --removed: #e11d48;
+  --removed-strong: #be123c;
+  --modified: #b45309;
+  --selection: rgba(13, 148, 136, 0.22);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0f172a;
-    --foreground: #f8fafc;
-    --card: #1e293b;
-    --card-foreground: #f8fafc;
-    --primary: #3b82f6;
-    --primary-foreground: #ffffff;
-    --secondary: #334155;
-    --secondary-foreground: #f8fafc;
-    --muted: #334155;
-    --muted-foreground: #94a3b8;
-    --accent: #334155;
-    --accent-foreground: #f8fafc;
-    --destructive: #ef4444;
-    --destructive-foreground: #ffffff;
-    --border: #334155;
-    --input: #334155;
-    --ring: #3b82f6;
+    --background: #141311;
+    --background-2: #0d0c0a;
+    --foreground: #eae6dd;
+    --surface: rgba(26, 25, 22, 0.66);
+    --sheet: #191815;
+    --ink: #f0ece3;
+    --ink-soft: #c8c3b8;
+    --muted-foreground: #97907f;
+    --hairline: rgba(234, 230, 221, 0.1);
+    --hairline-strong: rgba(234, 230, 221, 0.24);
+    --primary: #ece8de;
+    --primary-foreground: #181613;
+    --added: #2dd4bf;
+    --added-strong: #5eead4;
+    --removed: #fb7185;
+    --removed-strong: #fda4af;
+    --modified: #fbbf24;
+    --selection: rgba(45, 212, 191, 0.28);
   }
 }
 
@@ -61,11 +68,12 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+  background: var(--selection);
 }
 
 a {
@@ -73,199 +81,510 @@ a {
   text-decoration: none;
 }
 
+textarea::placeholder {
+  color: color-mix(in srgb, var(--muted-foreground) 65%, transparent);
+}
+
+:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--foreground) 45%, transparent);
+  outline-offset: 2px;
+}
+
 @layer components {
-  .glass-morphism {
-    @apply bg-gradient-to-br from-white/80 to-white/60 backdrop-blur-xl shadow-xl relative overflow-hidden;
-    background-image: 
-      linear-gradient(to bottom right, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.6)),
-      linear-gradient(to bottom right, rgba(59, 130, 246, 0.05), rgba(147, 51, 234, 0.05));
+  /* ---------------------------------------------------------------- */
+  /*  Ambient page backdrop                                            */
+  /* ---------------------------------------------------------------- */
+
+  .bg-art {
+    position: fixed;
+    inset: 0;
+    z-index: -10;
+    overflow: hidden;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        52rem 36rem at 12% -8%,
+        color-mix(in srgb, var(--removed) 7%, transparent),
+        transparent 65%
+      ),
+      radial-gradient(
+        52rem 36rem at 88% -8%,
+        color-mix(in srgb, var(--added) 7%, transparent),
+        transparent 65%
+      ),
+      radial-gradient(
+        64rem 42rem at 50% 114%,
+        color-mix(in srgb, var(--foreground) 5%, transparent),
+        transparent 70%
+      ),
+      linear-gradient(180deg, var(--background) 0%, var(--background-2) 100%);
   }
-  
-  .glass-morphism::before {
-    content: '';
+
+  /* Faint manuscript ruling, fading out below the hero */
+  .bg-rules {
     position: absolute;
     inset: 0;
-    border-radius: inherit;
-    padding: 1px;
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(147, 51, 234, 0.2));
-    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    pointer-events: none;
+    background: repeating-linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent 31px,
+      var(--hairline) 31px,
+      var(--hairline) 32px
+    );
+    -webkit-mask-image: radial-gradient(
+      120% 55% at 50% 0%,
+      black 0%,
+      transparent 78%
+    );
+    mask-image: radial-gradient(120% 55% at 50% 0%, black 0%, transparent 78%);
+    opacity: 0.55;
   }
-  
-  /* Variants for different colored borders */
-  .glass-morphism.border-rose::before {
-    background: linear-gradient(135deg, rgba(244, 63, 94, 0.2), rgba(251, 113, 133, 0.2));
+
+  /* Two oversized quotation marks: the “two texts” of the comparison */
+  .bg-glyph {
+    position: absolute;
+    font-size: clamp(18rem, 32vw, 32rem);
+    font-weight: 600;
+    line-height: 1;
+    color: color-mix(in srgb, var(--foreground) 4.5%, transparent);
+    user-select: none;
   }
-  
-  .glass-morphism.border-cyan::before {
-    background: linear-gradient(135deg, rgba(6, 182, 212, 0.2), rgba(34, 211, 238, 0.2));
+
+  .bg-glyph-left {
+    top: -0.1em;
+    left: -0.04em;
   }
-  
-  .glass-morphism.border-emerald::before {
-    background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(52, 211, 153, 0.2));
+
+  .bg-glyph-right {
+    bottom: -0.36em;
+    right: -0.02em;
   }
-  
-  .glass-morphism.border-indigo::before {
-    background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(129, 140, 248, 0.2));
-  }
-  
-  .glass-morphism-dark {
-    @apply bg-gradient-to-br from-gray-900/80 to-gray-900/60 backdrop-blur-xl shadow-xl relative overflow-hidden;
-    background-image: 
-      linear-gradient(to bottom right, rgba(17, 24, 39, 0.8), rgba(17, 24, 39, 0.6)),
-      linear-gradient(to bottom right, rgba(59, 130, 246, 0.1), rgba(147, 51, 234, 0.1));
-  }
-  
-  .glass-morphism-dark::before {
-    content: '';
+
+  .bg-noise {
     position: absolute;
     inset: 0;
-    border-radius: inherit;
-    padding: 1px;
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(147, 51, 234, 0.3));
-    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+    background-size: 180px 180px;
+    opacity: 0.05;
+    mix-blend-mode: multiply;
   }
-  
-  /* Dark mode variants */
-  .glass-morphism-dark.border-rose::before {
-    background: linear-gradient(135deg, rgba(244, 63, 94, 0.3), rgba(251, 113, 133, 0.3));
-  }
-  
-  .glass-morphism-dark.border-cyan::before {
-    background: linear-gradient(135deg, rgba(6, 182, 212, 0.3), rgba(34, 211, 238, 0.3));
-  }
-  
-  .glass-morphism-dark.border-emerald::before {
-    background: linear-gradient(135deg, rgba(16, 185, 129, 0.3), rgba(52, 211, 153, 0.3));
-  }
-  
-  .glass-morphism-dark.border-indigo::before {
-    background: linear-gradient(135deg, rgba(99, 102, 241, 0.3), rgba(129, 140, 248, 0.3));
-  }
-  
-  .diff-line-added {
-    @apply border-l-4 border-emerald-400;
-    background: linear-gradient(to right, rgba(16, 185, 129, 0.15), transparent);
-  }
-  
-  .diff-line-removed {
-    @apply border-l-4 border-rose-400;
-    background: linear-gradient(to right, rgba(244, 63, 94, 0.15), transparent);
-  }
-  
-  .diff-line-added-light {
-    @apply border-l-4 border-emerald-300;
-    background: linear-gradient(to right, rgba(16, 185, 129, 0.08), transparent);
-  }
-  
-  .diff-line-removed-light {
-    @apply border-l-4 border-rose-300;
-    background: linear-gradient(to right, rgba(244, 63, 94, 0.08), transparent);
-  }
-  
+
   @media (prefers-color-scheme: dark) {
-    .dark .diff-line-added {
-      background: linear-gradient(to right, rgba(16, 185, 129, 0.2), transparent);
-    }
-    
-    .dark .diff-line-removed {
-      background: linear-gradient(to right, rgba(244, 63, 94, 0.2), transparent);
-    }
-    
-    .dark .diff-line-added-light {
-      background: linear-gradient(to right, rgba(16, 185, 129, 0.1), transparent);
-    }
-    
-    .dark .diff-line-removed-light {
-      background: linear-gradient(to right, rgba(244, 63, 94, 0.1), transparent);
+    .bg-noise {
+      opacity: 0.06;
+      mix-blend-mode: screen;
     }
   }
-  
-  .diff-content-added {
-    @apply bg-emerald-400/30 dark:bg-emerald-500/30 rounded px-1 shadow-sm;
+
+  /* ---------------------------------------------------------------- */
+  /*  Surfaces & controls                                              */
+  /* ---------------------------------------------------------------- */
+
+  .card {
+    position: relative;
+    background: var(--surface);
+    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: blur(14px);
+    border: 1px solid var(--hairline);
+    border-radius: 1.25rem;
+    box-shadow:
+      0 1px 2px rgba(22, 18, 12, 0.04),
+      0 18px 44px -28px rgba(22, 18, 12, 0.28);
   }
-  
-  .diff-content-removed {
-    @apply bg-rose-400/30 dark:bg-rose-500/30 rounded px-1 shadow-sm;
+
+  @media (prefers-color-scheme: dark) {
+    .card {
+      box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.4),
+        0 20px 50px -30px rgba(0, 0, 0, 0.75);
+    }
   }
-  
-  .custom-scrollbar {
-    scrollbar-width: thin;
-    scrollbar-color: var(--muted-foreground) transparent;
+
+  .editor-card {
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
-  
-  /* Custom select dropdown styling */
-  select.bg-transparent {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
-    background-position: right 0.5rem center;
-    background-repeat: no-repeat;
-    background-size: 1.5em 1.5em;
-    padding-right: 2.5rem;
+
+  .editor-card:focus-within {
+    border-color: var(--hairline-strong);
+    box-shadow:
+      0 0 0 3px color-mix(in srgb, var(--foreground) 5%, transparent),
+      0 18px 44px -28px rgba(22, 18, 12, 0.28);
+  }
+
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.7rem;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+  }
+
+  .eyebrow::before,
+  .eyebrow::after {
+    content: "";
+    width: 4px;
+    height: 4px;
+    border-radius: 999px;
+    flex-shrink: 0;
+  }
+
+  .eyebrow::before {
+    background: var(--removed);
+    opacity: 0.75;
+  }
+
+  .eyebrow::after {
+    background: var(--added);
+    opacity: 0.75;
+  }
+
+  /* Inline track-changes motif used in copy */
+  .demo-del {
+    color: var(--removed-strong);
+    background: color-mix(in srgb, var(--removed) 10%, transparent);
+    border-radius: 0.3em;
+    padding: 0 0.22em;
+    text-decoration: line-through;
+    text-decoration-thickness: 1px;
+    text-decoration-color: color-mix(in srgb, var(--removed) 75%, transparent);
+  }
+
+  .demo-ins {
+    color: var(--added-strong);
+    background: color-mix(in srgb, var(--added) 12%, transparent);
+    border-radius: 0.3em;
+    padding: 0 0.22em;
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border-radius: 999px;
+    border: 0;
+    cursor: pointer;
+    background: var(--primary);
+    color: var(--primary-foreground);
+    padding: 0.6rem 1.6rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.16),
+      0 10px 24px -10px color-mix(in srgb, var(--primary) 55%, transparent);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .btn-primary:hover {
+    transform: translateY(-1px);
+    box-shadow:
+      0 2px 4px rgba(0, 0, 0, 0.16),
+      0 14px 30px -10px color-mix(in srgb, var(--primary) 60%, transparent);
+  }
+
+  .btn-primary:active {
+    transform: translateY(0);
+  }
+
+  .btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.4rem;
+    height: 2.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--hairline);
+    background: transparent;
+    cursor: pointer;
+    color: var(--muted-foreground);
+    transition: color 0.15s ease, border-color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .btn-icon:hover {
+    color: var(--ink);
+    border-color: var(--hairline-strong);
+    background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  }
+
+  .seg {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 3px;
+    border-radius: 999px;
+    border: 1px solid var(--hairline);
+    background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  }
+
+  .seg-item {
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 999px;
+    padding: 0.32rem 0.8rem;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--muted-foreground);
+    transition: color 0.15s ease, background-color 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+
+  .seg-item:hover {
+    color: var(--ink);
+  }
+
+  .seg-item[data-active="true"] {
+    background: var(--sheet);
+    color: var(--ink);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  }
+
+  .field {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 999px;
+    border: 1px solid var(--hairline);
+    padding: 0.42rem 0.9rem;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--ink-soft);
+    background: color-mix(in srgb, var(--sheet) 55%, transparent);
+    transition: border-color 0.15s ease;
+  }
+
+  .field:hover {
+    border-color: var(--hairline-strong);
+  }
+
+  .field select {
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+    background-color: transparent;
+    border: 0;
+    outline: none;
+    font: inherit;
+    font-weight: 600;
+    color: var(--ink);
+    cursor: pointer;
+    padding-right: 1.3rem;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23958d7e' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 0 center;
+    background-repeat: no-repeat;
+    background-size: 1em 1em;
   }
-  
-  @media (prefers-color-scheme: dark) {
-    .dark select.bg-transparent {
-      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23e5e7eb' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
-    }
+
+  .field select option {
+    background-color: var(--sheet);
+    color: var(--foreground);
   }
-  
+
+  .field input[type="checkbox"] {
+    width: 0.95rem;
+    height: 0.95rem;
+    accent-color: var(--ink);
+    cursor: pointer;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Stat chips                                                       */
+  /* ---------------------------------------------------------------- */
+
+  .stat-chip {
+    --chip: var(--ink-soft);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--chip) 28%, transparent);
+    background: color-mix(in srgb, var(--chip) 8%, transparent);
+    padding: 0.32rem 0.85rem;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--chip);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .stat-chip-added {
+    --chip: var(--added);
+  }
+
+  .stat-chip-removed {
+    --chip: var(--removed);
+  }
+
+  .stat-chip-modified {
+    --chip: var(--modified);
+  }
+
+  .stat-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 999px;
+    background: currentColor;
+    flex-shrink: 0;
+  }
+
+  .stat-label {
+    font-weight: 500;
+    opacity: 0.72;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Diff sheet                                                       */
+  /*                                                                   */
+  /*  Every row carries the same 3px left border (transparent when     */
+  /*  unchanged) and inline highlights add no horizontal padding, so   */
+  /*  line numbers and code columns never shift between rows or        */
+  /*  between the two panes.                                           */
+  /* ---------------------------------------------------------------- */
+
+  .diff-sheet {
+    background: var(--sheet);
+  }
+
+  .diff-row {
+    --row-tint: transparent;
+    display: flex;
+    align-items: stretch;
+    min-height: 1.5rem;
+    line-height: 1.5rem;
+    border-left: 3px solid transparent;
+    background: var(--row-tint);
+  }
+
+  .diff-row-removed {
+    border-left-color: var(--removed);
+    --row-tint: color-mix(in srgb, var(--removed) 12%, transparent);
+  }
+
+  .diff-row-removed-soft {
+    border-left-color: color-mix(in srgb, var(--removed) 40%, transparent);
+    --row-tint: color-mix(in srgb, var(--removed) 4.5%, transparent);
+  }
+
+  .diff-row-added {
+    border-left-color: var(--added);
+    --row-tint: color-mix(in srgb, var(--added) 12%, transparent);
+  }
+
+  .diff-row-added-soft {
+    border-left-color: color-mix(in srgb, var(--added) 40%, transparent);
+    --row-tint: color-mix(in srgb, var(--added) 4.5%, transparent);
+  }
+
+  /* Filler rows keep both panes the same height where the other side
+     has extra lines; hatched like a paste-up board. */
+  .diff-row-filler {
+    background-image: repeating-linear-gradient(
+      -45deg,
+      transparent 0,
+      transparent 4px,
+      var(--hairline) 4px,
+      var(--hairline) 5px
+    );
+  }
+
+  .diff-gutter {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    user-select: none;
+    background: linear-gradient(var(--row-tint), var(--row-tint)), var(--sheet);
+    border-right: 1px solid var(--hairline);
+  }
+
+  .diff-row-filler .diff-gutter {
+    background: transparent;
+  }
+
+  .diff-num {
+    width: 2.9rem;
+    padding-right: 0.5rem;
+    text-align: right;
+    font-size: 11px;
+    color: var(--muted-foreground);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .diff-sign {
+    width: 1.15rem;
+    text-align: center;
+    font-size: 11px;
+    font-weight: 700;
+  }
+
+  .diff-row-removed .diff-sign,
+  .diff-row-removed-soft .diff-sign {
+    color: var(--removed);
+  }
+
+  .diff-row-added .diff-sign,
+  .diff-row-added-soft .diff-sign {
+    color: var(--added);
+  }
+
+  .diff-code {
+    flex: 1;
+    white-space: pre;
+    padding: 0 1.5rem 0 0.75rem;
+    font-variant-ligatures: none;
+    tab-size: 4;
+  }
+
+  .diff-content-removed {
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--removed) 24%, transparent);
+    box-shadow: inset 0 0 0 1px
+      color-mix(in srgb, var(--removed) 22%, transparent);
+  }
+
+  .diff-content-added {
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--added) 24%, transparent);
+    box-shadow: inset 0 0 0 1px
+      color-mix(in srgb, var(--added) 22%, transparent);
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Scrollbars                                                       */
+  /* ---------------------------------------------------------------- */
+
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--foreground) 25%, transparent)
+      transparent;
+  }
+
   .custom-scrollbar::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+    width: 10px;
+    height: 10px;
   }
-  
+
   .custom-scrollbar::-webkit-scrollbar-track {
     background: transparent;
   }
-  
-  .custom-scrollbar::-webkit-scrollbar-thumb {
-    background-color: var(--muted-foreground);
-    border-radius: 4px;
-  }
-  
-  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: var(--foreground);
-  }
-  
-  .line-content {
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE and Edge */
-  }
-  
-  .line-content::-webkit-scrollbar {
-    display: none; /* Chrome, Safari and Opera */
-  }
-}
 
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--foreground) 18%, transparent);
+    border-radius: 8px;
+    border: 3px solid transparent;
+    background-clip: content-box;
   }
-  
-  .animate-gradient {
-    background-size: 200% 200%;
-    animation: gradient 15s ease infinite;
-  }
-  
-  @keyframes gradient {
-    0% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-    100% {
-      background-position: 0% 50%;
-    }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in srgb, var(--foreground) 32%, transparent);
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,26 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Fraunces, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  variable: "--font-serif",
+  style: ["normal", "italic"],
+  axes: ["opsz"],
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://textcompare.pro'),
@@ -60,8 +78,17 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/manifest.json" />
       </head>
-      <body className={`${inter.className} antialiased bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-blue-900 min-h-screen`}>
-        <div className="fixed inset-0 bg-gradient-to-br from-blue-50/50 via-white/50 to-purple-50/50 dark:from-gray-900/50 dark:via-gray-800/50 dark:to-blue-900/50 -z-10" />
+      <body
+        className={`${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable} font-sans antialiased`}
+      >
+        {/* Ambient backdrop: paper texture, manuscript rules and the two
+            quotation marks standing in for the two texts being compared. */}
+        <div aria-hidden className="bg-art">
+          <div className="bg-rules" />
+          <span className="bg-glyph bg-glyph-left font-serif italic">&ldquo;</span>
+          <span className="bg-glyph bg-glyph-right font-serif italic">&rdquo;</span>
+          <div className="bg-noise" />
+        </div>
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,15 +2,14 @@
 
 import TextCompare from '@/components/TextCompare';
 import { useState } from 'react';
-import { 
-  CheckCircle, 
-  Zap, 
-  Code, 
-  Shield, 
+import {
+  CheckCircle2,
+  Zap,
+  Code,
+  Shield,
   GitCompare,
   Eye,
-  Palette,
-  Globe
+  Feather,
 } from 'lucide-react';
 
 const features = [
@@ -21,23 +20,23 @@ const features = [
   },
   {
     icon: Code,
-    title: 'Syntax Highlighting',
-    description: 'Support for 10+ languages including JavaScript, Python, SQL, and more',
+    title: 'Format Aware',
+    description: 'Work with JSON, JavaScript, Python, SQL and more — with automatic JSON and SQL formatting',
   },
   {
     icon: Eye,
     title: 'Real-time Comparison',
-    description: 'Instant visual feedback with side-by-side comparison and diff navigation',
+    description: 'Instant visual feedback with side-by-side comparison, synchronized scrolling, and diff navigation',
   },
   {
-    icon: Palette,
-    title: 'Beautiful UI',
-    description: 'Modern glass-morphism design with dark mode support',
+    icon: Feather,
+    title: 'Editorial Design',
+    description: 'A calm ink-and-paper interface that keeps your eyes on the text, in light and dark mode',
   },
   {
     icon: Zap,
     title: 'High Performance',
-    description: 'Optimized for large texts with smart context folding and virtual scrolling',
+    description: 'Optimized for large texts with precise line alignment and efficient diff computation',
   },
   {
     icon: Shield,
@@ -46,10 +45,28 @@ const features = [
   },
 ];
 
+const steps = [
+  {
+    number: '01',
+    title: 'Paste Your Texts',
+    description: 'Simply paste or type your original and modified texts into the input areas',
+  },
+  {
+    number: '02',
+    title: 'Choose Options',
+    description: 'Select diff mode, formatting, and comparison options like ignore case',
+  },
+  {
+    number: '03',
+    title: 'View Results',
+    description: 'See highlighted differences with statistics and navigate through changes',
+  },
+];
+
 const faqItems = [
   {
     question: 'What makes Text Compare Pro different from other diff tools?',
-    answer: 'Text Compare Pro offers advanced features like multiple diff algorithms, syntax highlighting for 10+ languages, real-time formatting, and performance optimization for large texts. Our modern UI with glass-morphism effects provides a premium experience.',
+    answer: 'Text Compare Pro offers advanced features like multiple diff algorithms, support for 10+ formats, real-time formatting, and performance optimization for large texts. Its calm, editorial interface keeps the focus on your text.',
   },
   {
     question: 'Is my text data secure?',
@@ -79,33 +96,41 @@ export default function Home() {
   return (
     <main className="min-h-screen">
       {/* Text Compare Tool */}
-      <section className="min-h-screen flex flex-col">
+      <section className="flex min-h-screen flex-col">
         <div className="flex-1">
           <TextCompare onDiffToggle={setShowDiff} />
         </div>
       </section>
 
       {/* Features Section */}
-      <section className={`py-10 px-6 bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 transition-all duration-300 ${showDiff ? 'mt-0' : '-mt-32'}`}>
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-8">
-            <h2 className="text-3xl font-bold mb-3 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              Professional Text Comparison Features
+      <section
+        className={`border-t border-hairline px-6 py-24 transition-all duration-300 ${
+          showDiff ? 'mt-0' : '-mt-32'
+        }`}
+      >
+        <div className="mx-auto max-w-7xl">
+          <div className="mb-14 text-center">
+            <span className="eyebrow">Why Text Compare Pro</span>
+            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-4xl tracking-tight text-ink md:text-[2.75rem]">
+              Built for careful reading
             </h2>
-            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
-              Experience the most advanced text comparison tool with features designed for developers, writers, and professionals
+            <p className="mx-auto mt-4 max-w-2xl leading-relaxed text-muted">
+              The most considered text comparison tool, with features designed
+              for developers, writers, and professionals
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
             {features.map((feature, index) => (
               <div
                 key={index}
-                className="glass-morphism dark:glass-morphism-dark rounded-2xl p-6 hover:scale-105 transition-transform duration-300"
+                className="card group rounded-2xl p-6 transition-transform duration-300 hover:-translate-y-1"
               >
-                <feature.icon className="w-10 h-10 mb-3 text-blue-600 dark:text-blue-400" />
-                <h3 className="text-lg font-semibold mb-2">{feature.title}</h3>
-                <p className="text-sm text-gray-600 dark:text-gray-300">{feature.description}</p>
+                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl border border-hairline bg-sheet text-ink">
+                  <feature.icon className="h-[18px] w-[18px]" />
+                </div>
+                <h3 className="mb-2 text-[15px] font-semibold text-ink">{feature.title}</h3>
+                <p className="text-sm leading-relaxed text-muted">{feature.description}</p>
               </div>
             ))}
           </div>
@@ -113,70 +138,55 @@ export default function Home() {
       </section>
 
       {/* How It Works */}
-      <section className="py-20 px-6 bg-white dark:bg-gray-800">
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4">How Text Compare Pro Works</h2>
-            <p className="text-xl text-gray-600 dark:text-gray-300">
-              Simple, powerful, and intuitive text comparison in three steps
+      <section className="border-t border-hairline px-6 py-24">
+        <div className="mx-auto max-w-7xl">
+          <div className="mb-14 text-center">
+            <span className="eyebrow">How it works</span>
+            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-4xl tracking-tight text-ink md:text-[2.75rem]">
+              Three steps to clarity
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl leading-relaxed text-muted">
+              Simple, powerful, and intuitive text comparison
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div className="text-center">
-              <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex items-center justify-center text-white text-2xl font-bold">
-                1
+          <div className="grid grid-cols-1 gap-10 md:grid-cols-3">
+            {steps.map((step) => (
+              <div key={step.number} className="border-t border-hairline pt-8">
+                <div className="font-serif text-[3.5rem] italic leading-none text-ink opacity-20">
+                  {step.number}
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-ink">{step.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted">
+                  {step.description}
+                </p>
               </div>
-              <h3 className="text-xl font-semibold mb-3">Paste Your Texts</h3>
-              <p className="text-gray-600 dark:text-gray-300">
-                Simply paste or type your original and modified texts into the input areas
-              </p>
-            </div>
-
-            <div className="text-center">
-              <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex items-center justify-center text-white text-2xl font-bold">
-                2
-              </div>
-              <h3 className="text-xl font-semibold mb-3">Choose Options</h3>
-              <p className="text-gray-600 dark:text-gray-300">
-                Select diff mode, formatting, and comparison options like ignore case
-              </p>
-            </div>
-
-            <div className="text-center">
-              <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex items-center justify-center text-white text-2xl font-bold">
-                3
-              </div>
-              <h3 className="text-xl font-semibold mb-3">View Results</h3>
-              <p className="text-gray-600 dark:text-gray-300">
-                See highlighted differences with statistics and navigate through changes
-              </p>
-            </div>
+            ))}
           </div>
         </div>
       </section>
 
       {/* FAQ Section */}
-      <section className="py-20 px-6 bg-gradient-to-b from-white to-gray-50 dark:from-gray-800 dark:to-gray-900">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4">Frequently Asked Questions</h2>
-            <p className="text-xl text-gray-600 dark:text-gray-300">
+      <section className="border-t border-hairline px-6 py-24">
+        <div className="mx-auto max-w-4xl">
+          <div className="mb-14 text-center">
+            <span className="eyebrow">Questions &amp; answers</span>
+            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-4xl tracking-tight text-ink md:text-[2.75rem]">
+              Frequently asked questions
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl leading-relaxed text-muted">
               Everything you need to know about Text Compare Pro
             </p>
           </div>
 
-          <div className="space-y-6">
+          <div className="space-y-4">
             {faqItems.map((item, index) => (
-              <div
-                key={index}
-                className="glass-morphism dark:glass-morphism-dark rounded-2xl p-6"
-              >
-                <h3 className="text-lg font-semibold mb-3 flex items-start gap-3">
-                  <CheckCircle className="w-6 h-6 text-green-500 flex-shrink-0 mt-0.5" />
+              <div key={index} className="card rounded-2xl p-6">
+                <h3 className="flex items-start gap-3 text-[15px] font-semibold text-ink">
+                  <CheckCircle2 className="mt-0.5 h-[18px] w-[18px] shrink-0 text-added" />
                   {item.question}
                 </h3>
-                <p className="text-gray-600 dark:text-gray-300 ml-9">
+                <p className="ml-[30px] mt-2.5 text-sm leading-relaxed text-muted">
                   {item.answer}
                 </p>
               </div>
@@ -186,25 +196,22 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="py-12 px-6 bg-gray-100 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800">
-        <div className="max-w-7xl mx-auto text-center">
-          <div className="mb-6">
-            <h3 className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              Text Compare Pro
-            </h3>
-            <p className="text-gray-600 dark:text-gray-300 mt-2">
-              The professional text comparison tool for developers and writers
-            </p>
-          </div>
-          
-          <div className="flex items-center justify-center gap-4 text-sm text-gray-500 dark:text-gray-400">
-            <Globe className="w-4 h-4" />
-            <span>Privacy-first • No data collection • 100% client-side</span>
-          </div>
-          
-          <div className="mt-6 text-sm text-gray-500 dark:text-gray-400">
-            © 2024 Text Compare Pro. All rights reserved.
-          </div>
+      <footer className="border-t border-hairline px-6 py-14">
+        <div className="mx-auto max-w-7xl text-center">
+          <h3 className="font-serif text-2xl italic text-ink">Text Compare Pro</h3>
+          <p className="mt-2 text-sm text-muted">
+            The professional text comparison tool for developers and writers
+          </p>
+
+          <p className="mt-7 flex flex-wrap items-center justify-center gap-2.5 text-[11px] uppercase tracking-[0.18em] text-muted">
+            <span className="h-1 w-1 rounded-full bg-removed" />
+            Privacy-first · No data collection · 100% client-side
+            <span className="h-1 w-1 rounded-full bg-added" />
+          </p>
+
+          <p className="mt-7 text-xs text-muted">
+            © {new Date().getFullYear()} Text Compare Pro. All rights reserved.
+          </p>
         </div>
       </footer>
     </main>

--- a/components/DiffLine.tsx
+++ b/components/DiffLine.tsx
@@ -12,80 +12,58 @@ interface DiffLineProps {
   ignoreWhitespace?: boolean;
 }
 
-export default function DiffLine({ 
-  leftLine, 
-  rightLine, 
-  mode, 
+export default function DiffLine({
+  leftLine,
+  rightLine,
+  mode,
   side,
   ignoreCase = false,
   ignoreWhitespace = false
 }: DiffLineProps) {
   // For line mode, this component should not be used
   if (mode === 'lines') {
-    return <span className="whitespace-pre">{side === 'left' ? leftLine : rightLine}</span>;
+    return <span>{side === 'left' ? leftLine : rightLine}</span>;
   }
 
-  // For other modes, compute inline diff
   // Ensure we're comparing single lines without newlines
-  const cleanLeft = leftLine.replace(/\n/g, '');
-  const cleanRight = rightLine.replace(/\n/g, '');
-  
-  let processedLeft = cleanLeft;
-  let processedRight = cleanRight;
+  let left = leftLine.replace(/\n/g, '');
+  let right = rightLine.replace(/\n/g, '');
 
-  if (ignoreCase) {
-    processedLeft = processedLeft.toLowerCase();
-    processedRight = processedRight.toLowerCase();
+  // diffWords already treats whitespace as insignificant; chars/sentences
+  // need the runs collapsed manually when the option is enabled. Case is
+  // handled by the library's ignoreCase option so the original casing is
+  // preserved in the rendered output.
+  if (ignoreWhitespace && mode !== 'words') {
+    left = left.replace(/\s+/g, ' ').trim();
+    right = right.replace(/\s+/g, ' ').trim();
   }
 
-  if (ignoreWhitespace) {
-    processedLeft = processedLeft.replace(/\s+/g, ' ').trim();
-    processedRight = processedRight.replace(/\s+/g, ' ').trim();
-  }
-
-  let changes: Diff.Change[] = [];
-  
+  let changes: Diff.Change[];
   switch (mode) {
     case 'chars':
-      changes = Diff.diffChars(processedLeft, processedRight);
-      break;
-    case 'words':
-      changes = Diff.diffWords(processedLeft, processedRight);
+      changes = Diff.diffChars(left, right, { ignoreCase });
       break;
     case 'sentences':
-      changes = Diff.diffSentences(processedLeft, processedRight);
+      changes = Diff.diffSentences(left, right, { ignoreCase });
+      break;
+    default:
+      changes = Diff.diffWords(left, right, { ignoreCase });
       break;
   }
 
-  // If showing left side, show removed and unchanged parts
-  if (side === 'left') {
-    return (
-      <>
-        {changes.map((change, index) => {
-          if (change.added) return null;
-          return (
-            <span
-              key={index}
-              className={change.removed ? 'diff-content-removed whitespace-pre' : 'whitespace-pre'}
-            >
-              {change.value}
-            </span>
-          );
-        })}
-      </>
-    );
-  }
+  // The left pane renders removed + unchanged parts, the right pane renders
+  // added + unchanged parts. Highlights add no horizontal padding so the
+  // character columns stay aligned across both panes.
+  const highlightClass =
+    side === 'left' ? 'diff-content-removed' : 'diff-content-added';
 
-  // If showing right side, show added and unchanged parts
   return (
     <>
       {changes.map((change, index) => {
-        if (change.removed) return null;
+        if (side === 'left' ? change.added : change.removed) return null;
+        const isHighlighted = side === 'left' ? change.removed : change.added;
         return (
-          <span
-            key={index}
-            className={change.added ? 'diff-content-added whitespace-pre' : 'whitespace-pre'}
-          >
+          <span key={index} className={isHighlighted ? highlightClass : undefined}>
             {change.value}
           </span>
         );

--- a/components/LineDiffDisplay.tsx
+++ b/components/LineDiffDisplay.tsx
@@ -24,7 +24,7 @@ export default function LineDiffDisplay({
   diffRefs,
   onDiffCountChange
 }: LineDiffDisplayProps) {
-  
+
   // Use the diff library's native line comparison options so the diff tokens
   // keep their original line boundaries. Collapsing whitespace before line
   // diffing can turn multi-line text into one token and desynchronize the
@@ -32,159 +32,169 @@ export default function LineDiffDisplay({
   const { leftLines, rightLines } = useMemo(() => {
     return computeAlignedLineDiff(text1, text2, { ignoreCase, ignoreWhitespace });
   }, [text1, text2, ignoreCase, ignoreWhitespace]);
-  
-  const leftRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const rightRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const leftRowRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const leftPaneRef = useRef<HTMLDivElement | null>(null);
+  const rightPaneRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    // Clear previous refs
+    // Clear previous refs and group consecutive changed lines into blocks
     diffRefs.current.clear();
     let diffGroupIndex = 0;
     let inDiffBlock = false;
 
-    // Group consecutive diff lines into diff blocks
     leftLines.forEach((lineInfo, index) => {
       if (lineInfo.type !== 'unchanged') {
-        if (!inDiffBlock && leftRefs.current[index]) {
-          // Start of a new diff block
-          diffRefs.current.set(diffGroupIndex++, leftRefs.current[index]!);
+        const el = leftRowRefs.current[index];
+        if (!inDiffBlock && el) {
+          diffRefs.current.set(diffGroupIndex++, el);
           inDiffBlock = true;
         }
       } else {
-        // End of diff block
         inDiffBlock = false;
       }
     });
-    
-    // Notify parent component about the actual diff count
-    if (onDiffCountChange) {
-      onDiffCountChange(diffGroupIndex);
-    }
+
+    onDiffCountChange?.(diffGroupIndex);
   }, [leftLines, diffRefs, onDiffCountChange]);
 
-  return (
-    <div className="flex-1 grid grid-cols-1 xl:grid-cols-2 gap-3 min-h-0 overflow-hidden">
-      {/* Left Panel */}
-      <div className="glass-morphism dark:glass-morphism-dark border-rose rounded-2xl p-3 overflow-auto custom-scrollbar min-w-0">
-        <h3 className="font-medium mb-3 text-gray-700 dark:text-gray-200">Original</h3>
-        <div className="font-mono text-sm overflow-x-hidden">
-          {leftLines.map((lineInfo, index) => {
-            const rightLineInfo = rightLines[index];
-            // Show inline diff for non-line modes when:
-            // 1. Both lines exist and are marked as unchanged but content differs (ignoreCase/ignoreWhitespace)
-            // 2. Both lines exist and one is removed/added (for character/word level diff)
-            const showInlineDiff = diffMode !== 'lines' && (
-              (lineInfo.type === 'unchanged' && 
-               rightLineInfo?.type === 'unchanged' &&
-               lineInfo.content !== rightLineInfo.content) ||
-              (lineInfo.type === 'removed' && rightLineInfo?.type === 'added' &&
-               lineInfo.content && rightLineInfo.content)
-            );
-            
-            // Check if this is a complete line deletion (no corresponding line on right)
-            const isCompleteDeletion = lineInfo.type === 'removed' && rightLineInfo?.type === 'empty';
-            
-            return (
-              <div
-                key={index}
-                ref={el => {
-                  leftRefs.current[index] = el;
-                }}
-                className={`px-3 py-1 flex items-start ${
-                  lineInfo.type === 'removed' && (!showInlineDiff || isCompleteDeletion) ? 'diff-line-removed' : 
-                  lineInfo.type === 'removed' && showInlineDiff && !isCompleteDeletion ? 'diff-line-removed-light' : 
-                  showInlineDiff && lineInfo.type === 'unchanged' && lineInfo.content !== rightLineInfo?.content ? 'diff-line-removed-light' : ''
-                }`}
-              >
-                <span className="text-gray-500 text-xs mr-3 select-none flex-shrink-0 inline-block w-12 text-right">
-                  {lineInfo.originalLineNumber || ''}
-                </span>
-                <div className="flex-1 line-content">
-                  {lineInfo.type === 'empty' ? (
-                    <span className="text-gray-400">&nbsp;</span>
-                  ) : showInlineDiff ? (
-                    <DiffLine
-                      leftLine={lineInfo.content}
-                      rightLine={rightLineInfo.content}
-                      mode={diffMode}
-                      side="left"
-                      ignoreCase={ignoreCase}
-                      ignoreWhitespace={ignoreWhitespace}
-                    />
-                  ) : (
-                    <span className={
-                      lineInfo.type === 'removed' && (diffMode === 'lines' || isCompleteDeletion) ? 'diff-content-removed whitespace-pre' : 'whitespace-pre'
-                    }>
-                      {lineInfo.content}
-                    </span>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
+  // Mirror scrolling between the two panes so rows stay visually aligned
+  // whether the panes scroll vertically (fullscreen) or horizontally (long
+  // lines). Assigning an unchanged scroll position fires no event, so the
+  // ping-pong settles immediately.
+  const syncScroll =
+    (from: 'left' | 'right') => (event: React.UIEvent<HTMLDivElement>) => {
+      const source = event.currentTarget;
+      const target = from === 'left' ? rightPaneRef.current : leftPaneRef.current;
+      if (!target) return;
+      if (target.scrollTop !== source.scrollTop) {
+        target.scrollTop = source.scrollTop;
+      }
+      if (target.scrollLeft !== source.scrollLeft) {
+        target.scrollLeft = source.scrollLeft;
+      }
+    };
 
-      {/* Right Panel */}
-      <div className="glass-morphism dark:glass-morphism-dark border-cyan rounded-2xl p-3 overflow-auto custom-scrollbar min-w-0">
-        <h3 className="font-medium mb-3 text-gray-700 dark:text-gray-200">Modified</h3>
-        <div className="font-mono text-sm overflow-x-hidden">
-          {rightLines.map((lineInfo, index) => {
-            const leftLineInfo = leftLines[index];
-            // Show inline diff for non-line modes when:
-            // 1. Both lines exist and are marked as unchanged but content differs (ignoreCase/ignoreWhitespace)
-            // 2. Both lines exist and one is added/removed (for character/word level diff)
-            const showInlineDiff = diffMode !== 'lines' && (
-              (lineInfo.type === 'unchanged' && 
-               leftLineInfo?.type === 'unchanged' &&
-               lineInfo.content !== leftLineInfo.content) ||
-              (lineInfo.type === 'added' && leftLineInfo?.type === 'removed' &&
-               lineInfo.content && leftLineInfo.content)
-            );
-            
-            // Check if this is a complete line addition (no corresponding line on left)
-            const isCompleteAddition = lineInfo.type === 'added' && leftLineInfo?.type === 'empty';
-            
-            return (
-              <div
-                key={index}
-                ref={el => {
-                  rightRefs.current[index] = el;
-                }}
-                className={`px-3 py-1 flex items-start ${
-                  lineInfo.type === 'added' && (!showInlineDiff || isCompleteAddition) ? 'diff-line-added' : 
-                  lineInfo.type === 'added' && showInlineDiff && !isCompleteAddition ? 'diff-line-added-light' : 
-                  showInlineDiff && lineInfo.type === 'unchanged' && lineInfo.content !== leftLineInfo?.content ? 'diff-line-added-light' : ''
-                }`}
-              >
-                <span className="text-gray-500 text-xs mr-3 select-none flex-shrink-0 inline-block w-12 text-right">
-                  {lineInfo.originalLineNumber || ''}
-                </span>
-                <div className="flex-1 line-content">
-                  {lineInfo.type === 'empty' ? (
-                    <span className="text-gray-400">&nbsp;</span>
-                  ) : showInlineDiff ? (
-                    <DiffLine
-                      leftLine={leftLineInfo.content}
-                      rightLine={lineInfo.content}
-                      mode={diffMode}
-                      side="right"
-                      ignoreCase={ignoreCase}
-                      ignoreWhitespace={ignoreWhitespace}
-                    />
-                  ) : (
-                    <span className={
-                      lineInfo.type === 'added' && (diffMode === 'lines' || isCompleteAddition) ? 'diff-content-added whitespace-pre' : 'whitespace-pre'
-                    }>
-                      {lineInfo.content}
-                    </span>
-                  )}
-                </div>
-              </div>
-            );
-          })}
+  // Full literal class names so Tailwind's content scanner keeps the rules
+  // defined in globals.css (template strings would get tree-shaken away).
+  const rowClasses = {
+    removed: { full: 'diff-row-removed', soft: 'diff-row-removed-soft' },
+    added: { full: 'diff-row-added', soft: 'diff-row-added-soft' },
+  } as const;
+
+  const renderRows = (side: 'left' | 'right') => {
+    const lines = side === 'left' ? leftLines : rightLines;
+    const counterpart = side === 'left' ? rightLines : leftLines;
+    const changedType = side === 'left' ? 'removed' : 'added';
+    const counterpartChangedType = side === 'left' ? 'added' : 'removed';
+
+    return lines.map((lineInfo, index) => {
+      const other = counterpart[index];
+      // Show inline (word/char/sentence) diff when:
+      // 1. Both lines are "unchanged" but their raw content differs
+      //    (ignoreCase / ignoreWhitespace comparisons), or
+      // 2. The pair is a modification: removed on the left, added on the
+      //    right, both with content.
+      const showInlineDiff =
+        diffMode !== 'lines' &&
+        !!other &&
+        ((lineInfo.type === 'unchanged' &&
+          other.type === 'unchanged' &&
+          lineInfo.content !== other.content) ||
+          (lineInfo.type === changedType &&
+            other.type === counterpartChangedType &&
+            !!lineInfo.content &&
+            !!other.content));
+
+      let rowClass = '';
+      if (lineInfo.type === 'empty') {
+        rowClass = 'diff-row-filler';
+      } else if (lineInfo.type === changedType) {
+        rowClass = showInlineDiff
+          ? rowClasses[changedType].soft
+          : rowClasses[changedType].full;
+      } else if (showInlineDiff) {
+        rowClass = rowClasses[changedType].soft;
+      }
+
+      const sign =
+        lineInfo.type === 'removed' ? '−' : lineInfo.type === 'added' ? '+' : '';
+
+      return (
+        <div
+          key={index}
+          ref={
+            side === 'left'
+              ? (el) => {
+                  leftRowRefs.current[index] = el;
+                }
+              : undefined
+          }
+          data-diff-type={lineInfo.type}
+          className={`diff-row ${rowClass}`}
+        >
+          <span className="diff-gutter">
+            <span className="diff-num">{lineInfo.originalLineNumber ?? ''}</span>
+            <span className="diff-sign">{sign}</span>
+          </span>
+          <span className="diff-code">
+            {lineInfo.type === 'empty' ? (
+              ''
+            ) : showInlineDiff && other ? (
+              <DiffLine
+                leftLine={side === 'left' ? lineInfo.content : other.content}
+                rightLine={side === 'left' ? other.content : lineInfo.content}
+                mode={diffMode}
+                side={side}
+                ignoreCase={ignoreCase}
+                ignoreWhitespace={ignoreWhitespace}
+              />
+            ) : (
+              lineInfo.content
+            )}
+          </span>
         </div>
-      </div>
+      );
+    });
+  };
+
+  const renderPanel = (side: 'left' | 'right') => {
+    const isLeft = side === 'left';
+    const lines = isLeft ? leftLines : rightLines;
+    const lineCount = lines.filter((line) => line.type !== 'empty').length;
+
+    return (
+      <section className="card flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl">
+        <header className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-2.5">
+          <div className="flex items-center gap-2.5">
+            <span
+              className={`h-2 w-2 rounded-full ${isLeft ? 'bg-removed' : 'bg-added'}`}
+            />
+            <h3 className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">
+              {isLeft ? 'Original' : 'Modified'}
+            </h3>
+          </div>
+          <span className="font-mono text-[11px] tabular-nums text-muted">
+            {lineCount} lines
+          </span>
+        </header>
+        <div
+          ref={isLeft ? leftPaneRef : rightPaneRef}
+          onScroll={syncScroll(side)}
+          className="diff-sheet custom-scrollbar min-h-0 flex-1 overflow-auto"
+        >
+          <div className="w-max min-w-full py-1.5 font-mono text-[12.5px] leading-6 text-foreground">
+            {renderRows(side)}
+          </div>
+        </div>
+      </section>
+    );
+  };
+
+  return (
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 xl:grid-cols-2">
+      {renderPanel('left')}
+      {renderPanel('right')}
     </div>
   );
 }

--- a/components/ScrollIndicator.tsx
+++ b/components/ScrollIndicator.tsx
@@ -14,71 +14,50 @@ interface ScrollIndicatorProps {
   isVisible: boolean;
 }
 
-export default function ScrollIndicator({ diffRefs, totalHeight, isVisible }: ScrollIndicatorProps) {
-  // const [scrollPercentage, setScrollPercentage] = useState(0);
-  // const [viewportHeight, setViewportHeight] = useState(0);
-
+export default function ScrollIndicator({
+  diffRefs,
+  totalHeight,
+  isVisible
+}: ScrollIndicatorProps) {
   const diffPositions = useMemo(() => {
     const positions: DiffPosition[] = [];
+    if (!totalHeight) return positions;
+
     diffRefs.forEach((element) => {
       const rect = element.getBoundingClientRect();
       const absoluteTop = window.pageYOffset + rect.top;
       const percentage = (absoluteTop / totalHeight) * 100;
-      
-      // Determine type based on element classes
-      const isAdded = element.classList.contains('diff-line-added') || 
-                      element.classList.contains('diff-line-added-light');
-      const isRemoved = element.classList.contains('diff-line-removed') || 
-                        element.classList.contains('diff-line-removed-light');
-      
-      if (isAdded || isRemoved) {
-        positions.push({
-          top: percentage,
-          type: isAdded ? 'added' : 'removed'
-        });
-      }
+
+      // Each tracked element is the first row of a diff block; rows carry
+      // their type in a data attribute. A block starting with a removed row
+      // is a deletion/modification, one starting with a filler row marks a
+      // pure addition.
+      const type = element.dataset.diffType === 'removed' ? 'removed' : 'added';
+      positions.push({ top: percentage, type });
     });
+
     return positions;
   }, [diffRefs, totalHeight]);
-
-  // useEffect(() => {
-  //   const updateScrollInfo = () => {
-  //     const scrollTop = window.pageYOffset;
-  //     const docHeight = document.documentElement.scrollHeight;
-  //     const winHeight = window.innerHeight;
-      
-  //     setScrollPercentage((scrollTop / (docHeight - winHeight)) * 100);
-  //     setViewportHeight((winHeight / docHeight) * 100);
-  //   };
-
-  //   updateScrollInfo();
-  //   window.addEventListener('scroll', updateScrollInfo);
-  //   window.addEventListener('resize', updateScrollInfo);
-
-  //   return () => {
-  //     window.removeEventListener('scroll', updateScrollInfo);
-  //     window.removeEventListener('resize', updateScrollInfo);
-  //   };
-  // }, []);
 
   if (!isVisible || diffPositions.length === 0) return null;
 
   return (
-    <div className="fixed right-4 top-0 h-full w-2 bg-gradient-to-b from-purple-200 via-blue-200 to-pink-200 dark:from-purple-800 dark:via-blue-800 dark:to-pink-800 rounded-full opacity-50 z-30 pointer-events-none">
-      {/* Diff markers */}
+    <div
+      className="pointer-events-none fixed bottom-12 right-2 top-12 z-30 w-[3px] rounded-full"
+      style={{ background: 'var(--hairline)' }}
+    >
       {diffPositions.map((pos, index) => (
         <motion.div
           key={index}
-          className={`absolute left-0 w-full h-2 rounded-full ${
-            pos.type === 'added' 
-              ? 'bg-gradient-to-r from-emerald-400 to-teal-400 shadow-lg shadow-emerald-300/50' 
-              : 'bg-gradient-to-r from-rose-400 to-pink-400 shadow-lg shadow-rose-300/50'
-          }`}
-          style={{ top: `${pos.top}%` }}
-          initial={{ opacity: 0, scaleX: 0 }}
-          animate={{ opacity: 0.8, scaleX: 1 }}
-          transition={{ delay: index * 0.05 }}
-          whileHover={{ opacity: 1, scaleX: 1.5 }}
+          className="absolute -left-[2.5px] h-2 w-2 rounded-full"
+          style={{
+            top: `${pos.top}%`,
+            background: pos.type === 'added' ? 'var(--added)' : 'var(--removed)',
+            boxShadow: '0 0 0 2px var(--sheet)'
+          }}
+          initial={{ opacity: 0, scale: 0 }}
+          animate={{ opacity: 0.9, scale: 1 }}
+          transition={{ delay: Math.min(index * 0.03, 0.5) }}
         />
       ))}
     </div>

--- a/components/TextCompare.tsx
+++ b/components/TextCompare.tsx
@@ -2,25 +2,16 @@
 
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { 
-  ChevronUp, 
-  ChevronDown, 
-  Copy, 
+import {
+  ChevronUp,
+  ChevronDown,
+  Copy,
   Check,
-  Settings,
-  FileText,
-  Code,
-  Database,
-  Braces,
-  Hash,
-  Type,
+  FileCode2,
   Maximize2,
   Minimize2,
   RotateCcw,
-  FileCode2,
-  Plus,
-  Minus,
-  AlertCircle,
+  ArrowLeftRight,
   CheckCircle2,
   GitCompare,
   ArrowUp
@@ -30,16 +21,16 @@ import LineDiffDisplay from './LineDiffDisplay';
 import ScrollIndicator from './ScrollIndicator';
 
 const formatOptions = [
-  { value: 'plain', label: 'Plain Text', icon: FileText },
-  { value: 'json', label: 'JSON', icon: Braces },
-  { value: 'javascript', label: 'JavaScript', icon: Code },
-  { value: 'typescript', label: 'TypeScript', icon: Code },
-  { value: 'python', label: 'Python', icon: Code },
-  { value: 'sql', label: 'SQL', icon: Database },
-  { value: 'java', label: 'Java', icon: Code },
-  { value: 'csharp', label: 'C#', icon: Hash },
-  { value: 'html', label: 'HTML', icon: Code },
-  { value: 'css', label: 'CSS', icon: Type },
+  { value: 'plain', label: 'Plain Text' },
+  { value: 'json', label: 'JSON' },
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'typescript', label: 'TypeScript' },
+  { value: 'python', label: 'Python' },
+  { value: 'sql', label: 'SQL' },
+  { value: 'java', label: 'Java' },
+  { value: 'csharp', label: 'C#' },
+  { value: 'html', label: 'HTML' },
+  { value: 'css', label: 'CSS' },
 ];
 
 const diffModes: { value: DiffMode; label: string }[] = [
@@ -71,7 +62,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
   const [isScrolled, setIsScrolled] = useState(false);
   const [documentHeight, setDocumentHeight] = useState(0);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
-  
+
   const diffRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const statsBarRef = useRef<HTMLDivElement>(null);
   const isNavigating = useRef(false);
@@ -84,35 +75,12 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
     return computeDiff(formattedText1, formattedText2, diffOptions);
   }, [formattedText1, formattedText2, diffOptions, showDiff]);
 
-  // 保存上一次的选项值，用于检测变化
-  const prevOptionsRef = useRef({ diffOptions, format });
-  
-  // 当 diffOptions 或 format 改变时，重新执行比较
+  // The diff itself recomputes automatically through the memo above; when the
+  // options or format change we only need to re-anchor the navigation state.
   useEffect(() => {
-    // 检查是否真的有变化
-    const optionsChanged = 
-      prevOptionsRef.current.diffOptions !== diffOptions || 
-      prevOptionsRef.current.format !== format;
-    
-    if (showDiff && optionsChanged && (text1 || text2)) {
-      // 更新 ref
-      prevOptionsRef.current = { diffOptions, format };
-      
-      // 执行重置逻辑
-      setShowDiff(false);
-      setCurrentDiffIndex(-1);
-      diffRefs.current.clear();
-      
-      // 使用 setTimeout 确保状态更新完成后再重新比较
-      setTimeout(() => {
-        // 重新执行比较
-        setShowDiff(true);
-        setCurrentDiffIndex(-1);
-        diffRefs.current.clear();
-        onDiffToggle?.(true);
-      }, 50);
-    }
-  }, [diffOptions, format, showDiff, text1, text2, onDiffToggle]);
+    setCurrentDiffIndex(-1);
+    diffRefs.current.clear();
+  }, [diffOptions, format]);
 
   const diffCount = useMemo(() => {
     if (!diffResult) return 0;
@@ -124,6 +92,18 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
     setCurrentDiffIndex(-1);
     diffRefs.current.clear();
     onDiffToggle?.(true);
+  }, [onDiffToggle]);
+
+  const handleSwap = useCallback(() => {
+    setText1(text2);
+    setText2(text1);
+  }, [text1, text2]);
+
+  const handleReset = useCallback(() => {
+    setText1('');
+    setText2('');
+    setShowDiff(false);
+    onDiffToggle?.(false);
   }, [onDiffToggle]);
 
   const handleCopy = useCallback(async (text: string, side: 1 | 2) => {
@@ -144,19 +124,17 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
   const navigateToDiff = useCallback((direction: 'prev' | 'next') => {
     if (!diffResult || diffCount === 0) return;
 
-    // 1. 设置一个标记，表示我们正在通过代码主动导航
+    // Mark that navigation is code-driven so the scroll listener stays quiet
     isNavigating.current = true;
 
     let targetDiffIndex;
     if (direction === 'next') {
-      // 如果当前是 -1（未开始），则跳到第一个（0）
       if (currentDiffIndex === -1) {
         targetDiffIndex = 0;
       } else {
         targetDiffIndex = (currentDiffIndex + 1) % diffCount;
       }
     } else {
-      // 如果当前是 -1（未开始），则跳到最后一个
       if (currentDiffIndex === -1) {
         targetDiffIndex = diffCount - 1;
       } else {
@@ -164,26 +142,19 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
       }
     }
 
-    // 2. 立即更新 currentDiffIndex
     setCurrentDiffIndex(targetDiffIndex);
-    
-    // 3. 滚动到目标元素
+
     const diffElements = Array.from(diffRefs.current.values());
     if (targetDiffIndex < diffElements.length) {
-      // 现在 diffRefs 中存储的是每个差异组的第一个元素
-      // 所以可以直接使用 targetDiffIndex
       diffElements[targetDiffIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
 
-    // 4. 设置一个定时器，在滚动动画结束后清除标记。
-    //    这样用户自己手动滚动时，滚动监听又能正常工作了。
-    //    700ms 通常足够完成一个平滑滚动动画。
+    // Release the flag once the smooth scroll has settled so manual
+    // scrolling updates the index again.
     setTimeout(() => {
       isNavigating.current = false;
     }, 700);
-
   }, [currentDiffIndex, diffCount, diffResult]);
-
 
   // Notify parent when showDiff changes
   useEffect(() => {
@@ -193,7 +164,6 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
   // Monitor scroll position and document height
   useEffect(() => {
     const handleScroll = () => {
-      // 如果是代码触发的导航滚动，则忽略本次滚动事件，防止冲突
       if (isNavigating.current) {
         return;
       }
@@ -202,57 +172,46 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
         const rect = statsBarRef.current.getBoundingClientRect();
         setIsScrolled(rect.bottom < 0);
       }
-      
-      // 检查是否需要显示返回顶部按钮
+
       const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
       setShowScrollToTop(scrollTop > 200);
-      
+
       // Update current diff index based on scroll position
       if (diffRefs.current.size > 0 && diffCount > 0) {
         const diffElements = Array.from(diffRefs.current.values());
         const viewportCenter = window.innerHeight / 2;
-        
-        // 找到最接近视口中心的差异组
+
         let closestIndex = 0;
         let closestDistance = Infinity;
-        
+
         diffElements.forEach((element, index) => {
           const rect = element.getBoundingClientRect();
-          const elementTop = rect.top;
-          const distance = Math.abs(elementTop - viewportCenter);
-          
+          const distance = Math.abs(rect.top - viewportCenter);
+
           if (distance < closestDistance) {
             closestDistance = distance;
             closestIndex = index;
           }
         });
-        
-        // 只有在用户已经开始导航或滚动后才更新索引
-        // 如果当前是 -1 且最接近的是第 0 个，只有当它真正进入视口中心区域才更新
+
         if (currentDiffIndex === -1) {
           const firstElement = diffElements[0];
           if (firstElement) {
             const rect = firstElement.getBoundingClientRect();
-            const viewportCenter = window.innerHeight / 2;
-            // 只有当第一个差异真正接近视口中心时才更新到 0
             if (Math.abs(rect.top - viewportCenter) < 100) {
               setCurrentDiffIndex(0);
             }
           }
-        } else if (currentDiffIndex !== -1) {
-          // 检查是否应该重置为 -1（用户滚动到顶部）
+        } else {
           const firstElement = diffElements[0];
           if (firstElement) {
             const rect = firstElement.getBoundingClientRect();
-            const viewportCenter = window.innerHeight / 2;
-            // 如果第一个差异在视口中心下方很远，说明用户在顶部
             if (rect.top > viewportCenter + 100) {
               setCurrentDiffIndex(-1);
               return;
             }
           }
-          
-          // 否则更新为最接近的索引
+
           if (closestIndex !== currentDiffIndex && closestIndex >= 0 && closestIndex < diffCount) {
             setCurrentDiffIndex(closestIndex);
           }
@@ -260,23 +219,20 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
       }
     };
 
-
     const updateDocumentHeight = () => {
       setDocumentHeight(document.documentElement.scrollHeight);
     };
 
     handleScroll();
     updateDocumentHeight();
-    
+
     window.addEventListener('scroll', handleScroll);
     window.addEventListener('resize', updateDocumentHeight);
-    
-    // Update height when diff results change
+
     const observer = new ResizeObserver(updateDocumentHeight);
     if (document.body) {
       observer.observe(document.body);
     }
-    
 
     return () => {
       window.removeEventListener('scroll', handleScroll);
@@ -285,252 +241,263 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
     };
   }, [showDiff, currentDiffIndex, diffCount]);
 
+  const renderEditor = (side: 1 | 2) => {
+    const isOriginal = side === 1;
+    const value = isOriginal ? text1 : text2;
+    const setValue = isOriginal ? setText1 : setText2;
+    const copied = isOriginal ? copied1 : copied2;
+    const lineCount = value ? value.split('\n').length : 0;
+
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: isOriginal ? 0.15 : 0.2 }}
+        className="min-w-0"
+      >
+        <div className="card editor-card flex h-64 flex-col overflow-hidden rounded-2xl">
+          <div className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-2.5">
+            <div className="flex items-center gap-2.5">
+              <span
+                className={`h-2 w-2 rounded-full ${isOriginal ? 'bg-removed' : 'bg-added'}`}
+              />
+              <label className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">
+                {isOriginal ? 'Original' : 'Modified'}
+              </label>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="hidden font-mono text-[11px] tabular-nums text-muted sm:inline">
+                {lineCount} ln · {value.length} ch
+              </span>
+              <button
+                onClick={() => handleCopy(value, side)}
+                className="text-muted transition-colors hover:text-ink"
+                title="Copy to clipboard"
+              >
+                {copied ? <Check size={14} className="text-added" /> : <Copy size={14} />}
+              </button>
+            </div>
+          </div>
+          <textarea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={
+              isOriginal
+                ? 'Paste or type your original text here...'
+                : 'Paste or type your modified text here...'
+            }
+            spellCheck={false}
+            className="custom-scrollbar w-full flex-1 resize-none bg-transparent px-4 py-3 font-mono text-[13px] leading-6 text-foreground outline-none"
+          />
+        </div>
+      </motion.div>
+    );
+  };
 
   return (
-    <div className={`${isFullscreen ? 'fixed inset-0 z-40 bg-background' : ''} flex flex-col h-full`}>
+    <div
+      className={`${
+        isFullscreen ? 'fixed inset-0 z-40 overflow-y-auto bg-background pt-6' : ''
+      } flex h-full flex-col`}
+    >
       {/* Header */}
-      <header className="px-6 py-4 text-center">
-        <motion.h1 
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-2"
-        >
-          Text Compare Pro
-        </motion.h1>
-        <motion.p 
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-          className="text-gray-600 dark:text-gray-300 text-lg max-w-2xl mx-auto"
-        >
-          Professional text comparison with advanced diff algorithms, syntax highlighting, and real-time analysis
-        </motion.p>
-      </header>
+      {!isFullscreen && (
+        <header className="px-6 pb-10 pt-14 text-center md:pt-20">
+          <motion.div
+            initial={{ opacity: 0, y: -12 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex justify-center"
+          >
+            <span className="eyebrow">Side-by-side diff · Private by design</span>
+          </motion.div>
+          <motion.h1
+            initial={{ opacity: 0, y: -16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.05 }}
+            className="mx-auto mt-5 max-w-3xl font-serif text-5xl font-medium tracking-tight text-ink md:text-[4.25rem] md:leading-[1.05]"
+          >
+            Text Compare <em className="italic">Pro</em>
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-muted md:text-lg"
+          >
+            The editorial-grade diff for prose and code. Find every{' '}
+            <del className="demo-del">chnage</del>{' '}
+            <ins className="demo-ins">change</ins> in seconds — beautifully
+            highlighted, entirely in your browser.
+          </motion.p>
+        </header>
+      )}
 
       {/* Input Section */}
-      <div className="px-6 mb-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-7xl mx-auto">
-          {/* Left Input */}
-          <motion.div
-            initial={{ opacity: 0, x: -50 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.2 }}
-            className="relative"
-          >
-            <div className="glass-morphism dark:glass-morphism-dark rounded-2xl p-6 h-64 transition-all duration-300 hover:shadow-2xl">
-              <div className="flex justify-between items-center mb-3">
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
-                  Original Text
-                </label>
-                <button
-                  onClick={() => handleCopy(text1, 1)}
-                  className="p-2 rounded-lg hover:bg-gradient-to-br hover:from-gray-100 hover:to-gray-200 dark:hover:from-gray-700 dark:hover:to-gray-600 transition-all"
-                >
-                  {copied1 ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
-                </button>
-              </div>
-              <textarea
-                value={text1}
-                onChange={(e) => setText1(e.target.value)}
-                placeholder="Paste or type your original text here..."
-                className="w-full h-40 bg-transparent resize-none outline-none placeholder-gray-400 custom-scrollbar"
-              />
-            </div>
-          </motion.div>
+      <div className="mb-4 px-6">
+        <div className="relative mx-auto grid max-w-7xl grid-cols-1 gap-5 md:grid-cols-2">
+          {renderEditor(1)}
 
-          {/* Right Input */}
-          <motion.div
-            initial={{ opacity: 0, x: 50 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: 0.3 }}
-            className="relative"
-          >
-            <div className="glass-morphism dark:glass-morphism-dark rounded-2xl p-6 h-64 transition-all duration-300 hover:shadow-2xl">
-              <div className="flex justify-between items-center mb-3">
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
-                  Modified Text
-                </label>
-                <button
-                  onClick={() => handleCopy(text2, 2)}
-                  className="p-2 rounded-lg hover:bg-gradient-to-br hover:from-gray-100 hover:to-gray-200 dark:hover:from-gray-700 dark:hover:to-gray-600 transition-all"
-                >
-                  {copied2 ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
-                </button>
-              </div>
-              <textarea
-                value={text2}
-                onChange={(e) => setText2(e.target.value)}
-                placeholder="Paste or type your modified text here..."
-                className="w-full h-40 bg-transparent resize-none outline-none placeholder-gray-400 custom-scrollbar"
-              />
-            </div>
-          </motion.div>
+          {/* Swap texts */}
+          <div className="absolute left-1/2 top-1/2 z-10 hidden -translate-x-1/2 -translate-y-1/2 md:block">
+            <motion.button
+              whileHover={{ scale: 1.08, rotate: 180 }}
+              whileTap={{ scale: 0.92 }}
+              onClick={handleSwap}
+              title="Swap texts"
+              className="card flex h-10 w-10 items-center justify-center rounded-full text-muted transition-colors hover:text-ink"
+            >
+              <ArrowLeftRight size={15} />
+            </motion.button>
+          </div>
+
+          {renderEditor(2)}
         </div>
 
         {/* Controls */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4 }}
-          className="max-w-7xl mx-auto mt-4"
+          transition={{ delay: 0.25 }}
+          className="mx-auto mt-5 max-w-7xl"
         >
-          <div className="glass-morphism dark:glass-morphism-dark border-indigo rounded-2xl p-6">
-            <div className="flex flex-wrap items-center gap-4">
+          <div className="card rounded-2xl px-4 py-3.5 md:px-5">
+            <div className="flex flex-wrap items-center gap-3">
               {/* Format Selector */}
-              <div className="flex items-center gap-2 bg-white/30 dark:bg-gray-800/30 rounded-lg px-3 py-1.5 border border-blue-200/50 dark:border-purple-700/50">
-                <Settings size={16} className="text-blue-600 dark:text-purple-400" />
-                <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Format:</span>
+              <label className="field" title="Source format">
+                <FileCode2 size={14} className="shrink-0 text-muted" />
                 <select
                   value={format}
                   onChange={(e) => setFormat(e.target.value)}
-                  className="bg-transparent border-0 outline-none focus:ring-0 text-sm font-medium text-gray-700 dark:text-gray-200 cursor-pointer min-w-[120px]"
+                  aria-label="Source format"
                 >
                   {formatOptions.map(option => (
-                    <option key={option.value} value={option.value} className="bg-white dark:bg-gray-800">
+                    <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
                   ))}
                 </select>
-              </div>
+              </label>
 
               {/* Diff Mode */}
-              <div className="flex items-center gap-2 bg-white/30 dark:bg-gray-800/30 rounded-lg px-3 py-1.5 border border-purple-200/50 dark:border-blue-700/50">
-                <GitCompare size={16} className="text-purple-600 dark:text-blue-400" />
-                <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Mode:</span>
-                <select
-                  value={diffOptions.mode}
-                  onChange={(e) => setDiffOptions({ ...diffOptions, mode: e.target.value as DiffMode })}
-                  className="bg-transparent border-0 outline-none focus:ring-0 text-sm font-medium text-gray-700 dark:text-gray-200 cursor-pointer min-w-[100px]"
-                >
-                  {diffModes.map(mode => (
-                    <option key={mode.value} value={mode.value} className="bg-white dark:bg-gray-800">
-                      {mode.label}
-                    </option>
-                  ))}
-                </select>
+              <div className="seg" role="group" aria-label="Diff mode">
+                {diffModes.map(mode => (
+                  <button
+                    key={mode.value}
+                    type="button"
+                    data-active={diffOptions.mode === mode.value}
+                    onClick={() => setDiffOptions({ ...diffOptions, mode: mode.value })}
+                    className="seg-item"
+                  >
+                    {mode.label}
+                  </button>
+                ))}
               </div>
 
               {/* Options */}
-              <label className="flex items-center gap-2 cursor-pointer bg-white/30 dark:bg-gray-800/30 rounded-lg px-3 py-1.5 border border-gray-200/50 dark:border-gray-700/50 hover:bg-white/40 dark:hover:bg-gray-800/40 transition-colors">
+              <label className="field cursor-pointer select-none">
                 <input
                   type="checkbox"
                   checked={diffOptions.ignoreCase}
                   onChange={(e) => setDiffOptions({ ...diffOptions, ignoreCase: e.target.checked })}
-                  className="rounded border-gray-300 text-blue-500 focus:ring-blue-500 w-4 h-4"
                 />
-                <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Ignore Case</span>
+                Ignore case
               </label>
 
-              <label className="flex items-center gap-2 cursor-pointer bg-white/30 dark:bg-gray-800/30 rounded-lg px-3 py-1.5 border border-gray-200/50 dark:border-gray-700/50 hover:bg-white/40 dark:hover:bg-gray-800/40 transition-colors">
+              <label className="field cursor-pointer select-none">
                 <input
                   type="checkbox"
                   checked={diffOptions.ignoreWhitespace}
                   onChange={(e) => setDiffOptions({ ...diffOptions, ignoreWhitespace: e.target.checked })}
-                  className="rounded border-gray-300 text-blue-500 focus:ring-blue-500 w-4 h-4"
                 />
-                <span className="text-sm font-medium text-gray-600 dark:text-gray-300">Ignore Whitespace</span>
+                Ignore whitespace
               </label>
 
-              {/* Compare Button */}
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={handleCompare}
-                className="ml-auto bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 text-white px-6 py-2 rounded-lg font-medium shadow-lg hover:shadow-xl hover:from-blue-600 hover:via-purple-600 hover:to-pink-600 transition-all duration-300"
-              >
-                Compare
-              </motion.button>
+              <div className="ml-auto flex items-center gap-2">
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={handleReset}
+                  className="btn-icon"
+                  title="Reset"
+                >
+                  <RotateCcw size={15} />
+                </motion.button>
 
-              {/* Reset Button */}
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={() => {
-                  setText1('');
-                  setText2('');
-                  setShowDiff(false);
-                  onDiffToggle?.(false);
-                }}
-                className="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-              >
-                <RotateCcw size={18} />
-              </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={() => setIsFullscreen(!isFullscreen)}
+                  className="btn-icon"
+                  title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                >
+                  {isFullscreen ? <Minimize2 size={15} /> : <Maximize2 size={15} />}
+                </motion.button>
 
-              {/* Fullscreen Toggle */}
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={() => setIsFullscreen(!isFullscreen)}
-                className="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-              >
-                {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
-              </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.03 }}
+                  whileTap={{ scale: 0.97 }}
+                  onClick={handleCompare}
+                  className="btn-primary"
+                >
+                  <GitCompare size={15} />
+                  Compare
+                </motion.button>
+              </div>
             </div>
           </div>
         </motion.div>
       </div>
 
-      {/* Floating Stats Bar - Shows when scrolled */}
+      {/* Floating navigator - shows when the stats bar scrolls away */}
       {showDiff && diffResult && isScrolled && (
-        <div className="fixed top-1/2 -translate-y-1/2 right-8 z-50">
+        <div className="fixed right-5 top-1/2 z-50 -translate-y-1/2">
           <motion.div
-            initial={{ opacity: 0, x: 20 }}
+            initial={{ opacity: 0, x: 16 }}
             animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: 20 }}
-            className="glass-morphism dark:glass-morphism-dark rounded-2xl p-4 backdrop-blur-sm bg-white/30 dark:bg-gray-900/30 shadow-xl border border-white/10"
+            exit={{ opacity: 0, x: 16 }}
+            className="card flex flex-col items-center gap-2.5 rounded-full px-3 py-4"
           >
-            <div className="flex flex-col gap-3">
-              {diffResult.stats.total === 0 ? (
-                <div className="flex flex-col items-center gap-2 bg-green-50 dark:bg-green-900/20 px-3 py-2 rounded-lg">
-                  <CheckCircle2 className="w-5 h-5 text-green-600" />
-                  <span className="text-xs text-green-700 dark:text-green-400 font-semibold">Identical</span>
-                </div>
-              ) : (
-                <>
-                  <div className="flex flex-col items-center gap-1 bg-gradient-to-r from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 px-3 py-2 rounded-lg border border-green-200 dark:border-green-800">
-                    <Plus className="w-4 h-4 text-green-600" />
-                    <span className="text-sm font-semibold text-green-700 dark:text-green-400">{diffResult.stats.additions}</span>
-                  </div>
-                  <div className="flex flex-col items-center gap-1 bg-gradient-to-r from-red-50 to-red-100 dark:from-red-900/20 dark:to-red-800/20 px-3 py-2 rounded-lg border border-red-200 dark:border-red-800">
-                    <Minus className="w-4 h-4 text-red-600" />
-                    <span className="text-sm font-semibold text-red-700 dark:text-red-400">{diffResult.stats.deletions}</span>
-                  </div>
-                  <div className="flex flex-col items-center gap-1 bg-gradient-to-r from-amber-50 to-amber-100 dark:from-amber-900/20 dark:to-amber-800/20 px-3 py-2 rounded-lg border border-amber-200 dark:border-amber-800">
-                    <AlertCircle className="w-4 h-4 text-amber-600" />
-                    <span className="text-sm font-semibold text-amber-700 dark:text-amber-400">{diffResult.stats.modifications}</span>
-                  </div>
-                </>
-              )}
-              
-              {diffCount > 0 && (
-                <>
-                  <div className="h-px bg-gray-300 dark:bg-gray-600" />
-                  <div className="flex flex-col items-center gap-2">
-                    <div className="text-xs font-medium text-gray-700 dark:text-gray-300 text-center">
-                      {currentDiffIndex === -1 ? 0 : currentDiffIndex + 1} / {diffCount}
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <motion.button
-                        whileHover={{ scale: 1.1 }}
-                        whileTap={{ scale: 0.9 }}
-                        onClick={() => navigateToDiff('prev')}
-                        className="p-1.5 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 shadow-md transition-all"
-                      >
-                        <ChevronUp size={16} className="text-gray-700 dark:text-gray-300" />
-                      </motion.button>
-                      <motion.button
-                        whileHover={{ scale: 1.1 }}
-                        whileTap={{ scale: 0.9 }}
-                        onClick={() => navigateToDiff('next')}
-                        className="p-1.5 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 shadow-md transition-all"
-                      >
-                        <ChevronDown size={16} className="text-gray-700 dark:text-gray-300" />
-                      </motion.button>
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
+            {diffResult.stats.total === 0 ? (
+              <CheckCircle2 size={16} className="text-added" />
+            ) : (
+              <>
+                <span className="flex items-center gap-1.5 font-mono text-[10px] font-semibold tabular-nums text-added">
+                  <span className="h-1.5 w-1.5 rounded-full bg-added" />
+                  {diffResult.stats.additions}
+                </span>
+                <span className="flex items-center gap-1.5 font-mono text-[10px] font-semibold tabular-nums text-removed">
+                  <span className="h-1.5 w-1.5 rounded-full bg-removed" />
+                  {diffResult.stats.deletions}
+                </span>
+                <span className="flex items-center gap-1.5 font-mono text-[10px] font-semibold tabular-nums text-modified">
+                  <span className="h-1.5 w-1.5 rounded-full bg-modified" />
+                  {diffResult.stats.modifications}
+                </span>
+              </>
+            )}
+
+            {diffCount > 0 && (
+              <>
+                <div className="h-px w-6 bg-hairline" />
+                <span className="font-mono text-[10px] tabular-nums text-muted">
+                  {currentDiffIndex === -1 ? 0 : currentDiffIndex + 1}/{diffCount}
+                </span>
+                <button
+                  onClick={() => navigateToDiff('prev')}
+                  className="btn-icon !h-8 !w-8"
+                  title="Previous change"
+                >
+                  <ChevronUp size={14} />
+                </button>
+                <button
+                  onClick={() => navigateToDiff('next')}
+                  className="btn-icon !h-8 !w-8"
+                  title="Next change"
+                >
+                  <ChevronDown size={14} />
+                </button>
+              </>
+            )}
           </motion.div>
         </div>
       )}
@@ -542,68 +509,66 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
-            className="flex-1 px-6 pb-6"
+            className="min-h-0 flex-1 px-6 pb-6"
           >
-            <div className="max-w-7xl mx-auto h-full flex flex-col">
-              {/* Stats Bar - Normal Position */}
-              <div ref={statsBarRef} className="glass-morphism dark:glass-morphism-dark border-emerald rounded-2xl p-4 mb-4">
-                <div className="flex items-center justify-between flex-wrap gap-4">
-                  <div className="flex items-center gap-4">
+            <div className="mx-auto flex h-full max-w-7xl flex-col">
+              {/* Stats Bar */}
+              <div ref={statsBarRef} className="card mb-4 shrink-0 rounded-2xl px-4 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap items-center gap-2">
                     {diffResult.stats.total === 0 ? (
-                      <div className="flex items-center gap-3 bg-green-50 dark:bg-green-900/20 px-4 py-2 rounded-lg">
-                        <CheckCircle2 className="w-5 h-5 text-green-600" />
-                        <span className="text-green-700 dark:text-green-400 font-semibold">Files are identical</span>
-                      </div>
+                      <span className="stat-chip stat-chip-added">
+                        <CheckCircle2 size={13} />
+                        Documents are identical
+                      </span>
                     ) : (
                       <>
-                        <div className="flex items-center gap-2 bg-gradient-to-r from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 px-4 py-2 rounded-lg border border-green-200 dark:border-green-800">
-                          <Plus className="w-4 h-4 text-green-600" />
-                          <span className="text-sm font-semibold text-green-700 dark:text-green-400">{diffResult.stats.additions}</span>
-                          <span className="text-xs text-green-600 dark:text-green-500">additions</span>
-                        </div>
-                        <div className="flex items-center gap-2 bg-gradient-to-r from-red-50 to-red-100 dark:from-red-900/20 dark:to-red-800/20 px-4 py-2 rounded-lg border border-red-200 dark:border-red-800">
-                          <Minus className="w-4 h-4 text-red-600" />
-                          <span className="text-sm font-semibold text-red-700 dark:text-red-400">{diffResult.stats.deletions}</span>
-                          <span className="text-xs text-red-600 dark:text-red-500">deletions</span>
-                        </div>
-                        <div className="flex items-center gap-2 bg-gradient-to-r from-amber-50 to-amber-100 dark:from-amber-900/20 dark:to-amber-800/20 px-4 py-2 rounded-lg border border-amber-200 dark:border-amber-800">
-                          <AlertCircle className="w-4 h-4 text-amber-600" />
-                          <span className="text-sm font-semibold text-amber-700 dark:text-amber-400">{diffResult.stats.modifications}</span>
-                          <span className="text-xs text-amber-600 dark:text-amber-500">modified</span>
-                        </div>
-                        <div className="flex items-center gap-2 bg-gradient-to-r from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20 px-4 py-2 rounded-lg border border-blue-200 dark:border-blue-800">
-                          <FileCode2 className="w-4 h-4 text-blue-600" />
-                          <span className="text-sm font-semibold text-blue-700 dark:text-blue-400">{diffResult.stats.total}</span>
-                          <span className="text-xs text-blue-600 dark:text-blue-500">changes</span>
-                        </div>
+                        <span className="stat-chip stat-chip-added">
+                          <span className="stat-dot" />
+                          {diffResult.stats.additions}
+                          <span className="stat-label">added</span>
+                        </span>
+                        <span className="stat-chip stat-chip-removed">
+                          <span className="stat-dot" />
+                          {diffResult.stats.deletions}
+                          <span className="stat-label">removed</span>
+                        </span>
+                        <span className="stat-chip stat-chip-modified">
+                          <span className="stat-dot" />
+                          {diffResult.stats.modifications}
+                          <span className="stat-label">modified</span>
+                        </span>
+                        <span className="stat-chip">
+                          <span className="stat-dot" />
+                          {diffResult.stats.total}
+                          <span className="stat-label">changes</span>
+                        </span>
                       </>
                     )}
                   </div>
-                  
+
                   {diffCount > 0 && (
                     <div className="flex items-center gap-3">
-                      <div className="bg-gray-100 dark:bg-gray-800 px-3 py-1.5 rounded-lg flex items-center gap-2">
-                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          Change 0 / {diffCount}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <motion.button
-                          whileHover={{ scale: 1.1 }}
-                          whileTap={{ scale: 0.9 }}
+                      <span className="font-mono text-xs tabular-nums text-muted">
+                        {currentDiffIndex === -1 ? 0 : currentDiffIndex + 1}
+                        <span className="mx-1 opacity-60">/</span>
+                        {diffCount}
+                      </span>
+                      <div className="flex items-center gap-1.5">
+                        <button
                           onClick={() => navigateToDiff('prev')}
-                          className="p-2 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 shadow-md transition-all"
+                          className="btn-icon !h-8 !w-8"
+                          title="Previous change"
                         >
-                          <ChevronUp size={18} className="text-gray-700 dark:text-gray-300" />
-                        </motion.button>
-                        <motion.button
-                          whileHover={{ scale: 1.1 }}
-                          whileTap={{ scale: 0.9 }}
+                          <ChevronUp size={14} />
+                        </button>
+                        <button
                           onClick={() => navigateToDiff('next')}
-                          className="p-2 rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 shadow-md transition-all"
+                          className="btn-icon !h-8 !w-8"
+                          title="Next change"
                         >
-                          <ChevronDown size={18} className="text-gray-700 dark:text-gray-300" />
-                        </motion.button>
+                          <ChevronDown size={14} />
+                        </button>
                       </div>
                     </div>
                   )}
@@ -619,23 +584,19 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
                 ignoreWhitespace={diffOptions.ignoreWhitespace}
                 format={format}
                 diffRefs={diffRefs}
-                onDiffCountChange={() => {
-                  // 这个回调会在 LineDiffDisplay 重新计算 diff 后被调用
-                  // 确保 diffRefs 被正确填充
-                }}
               />
             </div>
           </motion.div>
         )}
       </AnimatePresence>
-      
+
       {/* Scroll Indicator */}
-      <ScrollIndicator 
-        diffRefs={diffRefs.current} 
+      <ScrollIndicator
+        diffRefs={diffRefs.current}
         totalHeight={documentHeight}
         isVisible={showDiff && diffResult !== null && diffResult.stats.total > 0}
       />
-      
+
       {/* Scroll to Top Button */}
       <AnimatePresence>
         {showScrollToTop && (
@@ -645,11 +606,12 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             exit={{ opacity: 0, scale: 0.8 }}
             transition={{ duration: 0.2 }}
             onClick={scrollToTop}
-            className="fixed bottom-8 right-8 p-3 rounded-full bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow-lg hover:shadow-xl hover:scale-110 transition-all duration-300 z-40"
-            whileHover={{ rotate: -10 }}
-            whileTap={{ scale: 0.9 }}
+            className="btn-primary fixed bottom-8 right-8 z-40 !h-12 !w-12 !p-0"
+            whileHover={{ scale: 1.08 }}
+            whileTap={{ scale: 0.92 }}
+            title="Back to top"
           >
-            <ArrowUp size={20} />
+            <ArrowUp size={18} />
           </motion.button>
         )}
       </AnimatePresence>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,37 @@ export default {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+        surface: "var(--surface)",
+        sheet: "var(--sheet)",
+        ink: {
+          DEFAULT: "var(--ink)",
+          soft: "var(--ink-soft)",
+        },
+        muted: "var(--muted-foreground)",
+        hairline: {
+          DEFAULT: "var(--hairline)",
+          strong: "var(--hairline-strong)",
+        },
+        added: {
+          DEFAULT: "var(--added)",
+          strong: "var(--added-strong)",
+        },
+        removed: {
+          DEFAULT: "var(--removed)",
+          strong: "var(--removed-strong)",
+        },
+        modified: "var(--modified)",
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", "ui-sans-serif", "system-ui", "sans-serif"],
+        serif: ["var(--font-serif)", "Georgia", "Times New Roman", "serif"],
+        mono: [
+          "var(--font-mono)",
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "monospace",
+        ],
       },
     },
   },


### PR DESCRIPTION
## Overview

A full visual redesign of Text Compare Pro into a calm, high-craft "ink & paper" editorial aesthetic, plus fixes for the long-standing diff alignment bugs (line numbers shifting horizontally, rows not lining up between panes).

## 🎨 Design overhaul

- **New "ink & paper" design system** — warm ivory / deep charcoal palette driven entirely by CSS variables, with a Fraunces serif display face paired with Inter (UI) and JetBrains Mono (code).
- **Ambient backdrop themed for text comparison** — two oversized ghosted quotation marks stand in for the two texts being compared, with a rose / teal dual glow that matches the Original / Modified panes, faint manuscript ruling, and subtle paper-grain noise. Works in light and dark mode.
- **Refined components** — hairline cards, a segmented control for diff mode, pill-style option fields, an ink primary button, compact stat chips, and a track-changes motif in the hero copy (~~chnage~~ → **change**).
- **New "swap texts" control** between the two editors.
- Features / How-it-works / FAQ / footer sections restyled to match.

## 🐛 Diff view fixes

- **Line numbers no longer shift horizontally.** Previously only changed rows had a 4px left border and inline highlights added horizontal padding, so the gutter and code columns jumped between rows. Every row now carries a constant-width left border (transparent when unchanged) and highlights add zero horizontal padding.
- **Rows stay vertically aligned across panes** — fixed row height, a sticky line-number gutter, hatched filler rows where one side has extra lines, and panel-level horizontal scrolling instead of per-line scrolling.
- **Synchronized scrolling** between the two panes, both vertical and horizontal.
- **Change counter** now tracks the current position (it was hardcoded to `0`).
- **Ignore-case** comparisons no longer lowercase the rendered text — casing is preserved and handled via the diff library's `ignoreCase` option.
- Removed the hide/show **flicker hack** that ran whenever diff options changed.
- Diff row color classes use literal names so Tailwind's content scanner keeps their styles (template-string class names were being tree-shaken away, which dropped the row tints entirely).

## ✅ Verification

Built (`next build`) and lint-clean, then driven end-to-end in a real browser with Playwright:

- Line + Words modes render with rows aligned across both panes; measured identical line-number / code-column X positions and identical row tops for every row pair.
- Horizontal scroll stays in sync (`scrollLeft` 300 = 300) and the sticky gutter remains pinned while scrolled.
- Change counter advances correctly (shows `1/5` after one "Next").
- Empty/identical input shows the "Documents are identical" state.
- Verified in dark mode; no console / page errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSzKjbfT5WAdioPaM5hYuB)_