### PR TITLE
Widen tool layout to full viewport width

### DIFF
--- a/components/LineDiffDisplay.tsx
+++ b/components/LineDiffDisplay.tsx
@@ -192,7 +192,7 @@ export default function LineDiffDisplay({
   };
 
   return (
-    <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 xl:grid-cols-2">
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-2">
       {renderPanel('left')}
       {renderPanel('right')}
     </div>

--- a/components/TextCompare.tsx
+++ b/components/TextCompare.tsx
@@ -334,7 +334,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
 
       {/* Input Section */}
       <div className="mb-4 px-6">
-        <div className="relative mx-auto grid max-w-7xl grid-cols-1 gap-5 md:grid-cols-2">
+        <div className="relative grid w-full grid-cols-1 gap-5 md:grid-cols-2">
           {renderEditor(1)}
 
           {/* Swap texts */}
@@ -358,7 +358,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.25 }}
-          className="mx-auto mt-5 max-w-7xl"
+          className="mt-5 w-full"
         >
           <div className="card rounded-2xl px-4 py-3.5 md:px-5">
             <div className="flex flex-wrap items-center gap-3">
@@ -511,7 +511,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             exit={{ opacity: 0, y: 20 }}
             className="min-h-0 flex-1 px-6 pb-6"
           >
-            <div className="mx-auto flex h-full max-w-7xl flex-col">
+            <div className="flex h-full w-full flex-col">
               {/* Stats Bar */}
               <div ref={statsBarRef} className="card mb-4 shrink-0 rounded-2xl px-4 py-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Overview

Follow-up to #5. The tool area was capped at `max-w-7xl` (1280px), so on wide screens each of the four boxes (two editors + two diff panes) was only ~610px wide — wasteful for a comparison tool, where width is exactly what you want. This widens the tool layout to the full viewport.

## Changes

- **Editors, toolbar, stats bar, and diff panes now stretch to full viewport width** (removed the `max-w-7xl` cap on the tool area).
- **Diff panes go side-by-side from the `lg` breakpoint** (1024px) instead of `xl` (1280px), so laptops get the two-column comparison too.
- Marketing sections (Features / How-it-works / FAQ / footer) keep their comfortable reading width — only the tool area was widened.

## Measured effect (Playwright)

| Viewport | Per-box width (before → after) |
|---|---|
| 1920px | ~610px → **926px** |
| 2560px | ~610px → **1246px** |

Built clean (`next build`) and re-verified in a real browser: row alignment, line-number gutter, and synchronized scrolling all hold at the new widths.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSzKjbfT5WAdioPaM5hYuB)_