### PR TITLE
Make layout adaptive across devices and maximize visible content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -321,6 +321,15 @@ textarea::placeholder {
     border-radius: 999px;
     border: 1px solid var(--hairline);
     background: color-mix(in srgb, var(--foreground) 4%, transparent);
+    /* On narrow screens the four mode labels can exceed the toolbar width;
+       let the control pan instead of breaking the layout. */
+    max-width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .seg::-webkit-scrollbar {
+    display: none;
   }
 
   .seg-item {
@@ -332,6 +341,8 @@ textarea::placeholder {
     font-size: 12px;
     font-weight: 600;
     color: var(--muted-foreground);
+    white-space: nowrap;
+    flex-shrink: 0;
     transition: color 0.15s ease, background-color 0.15s ease,
       box-shadow 0.15s ease;
   }
@@ -556,6 +567,37 @@ textarea::placeholder {
     background: color-mix(in srgb, var(--added) 24%, transparent);
     box-shadow: inset 0 0 0 1px
       color-mix(in srgb, var(--added) 22%, transparent);
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Small screens: slimmer gutter and quieter ornaments so the code  */
+  /*  itself gets as much width as possible.                           */
+  /* ---------------------------------------------------------------- */
+
+  @media (max-width: 640px) {
+    .eyebrow {
+      font-size: 10px;
+      letter-spacing: 0.16em;
+    }
+
+    .bg-glyph {
+      font-size: clamp(9rem, 40vw, 14rem);
+    }
+
+    .diff-num {
+      width: 2.1rem;
+      padding-right: 0.35rem;
+      font-size: 10px;
+    }
+
+    .diff-sign {
+      width: 0.95rem;
+      font-size: 10px;
+    }
+
+    .diff-code {
+      padding: 0 1rem 0 0.55rem;
+    }
   }
 
   /* ---------------------------------------------------------------- */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,14 +104,14 @@ export default function Home() {
 
       {/* Features Section */}
       <section
-        className={`border-t border-hairline px-6 py-24 transition-all duration-300 ${
+        className={`border-t border-hairline px-5 py-16 transition-all duration-300 md:px-6 md:py-24 ${
           showDiff ? 'mt-0' : '-mt-32'
         }`}
       >
         <div className="mx-auto max-w-7xl">
           <div className="mb-14 text-center">
             <span className="eyebrow">Why Text Compare Pro</span>
-            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-4xl tracking-tight text-ink md:text-[2.75rem]">
+            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-3xl tracking-tight text-ink sm:text-4xl md:text-[2.75rem]">
               Built for careful reading
             </h2>
             <p className="mx-auto mt-4 max-w-2xl leading-relaxed text-muted">
@@ -138,11 +138,11 @@ export default function Home() {
       </section>
 
       {/* How It Works */}
-      <section className="border-t border-hairline px-6 py-24">
+      <section className="border-t border-hairline px-5 py-16 md:px-6 md:py-24">
         <div className="mx-auto max-w-7xl">
           <div className="mb-14 text-center">
             <span className="eyebrow">How it works</span>
-            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-4xl tracking-tight text-ink md:text-[2.75rem]">
+            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-3xl tracking-tight text-ink sm:text-4xl md:text-[2.75rem]">
               Three steps to clarity
             </h2>
             <p className="mx-auto mt-4 max-w-2xl leading-relaxed text-muted">
@@ -167,11 +167,11 @@ export default function Home() {
       </section>
 
       {/* FAQ Section */}
-      <section className="border-t border-hairline px-6 py-24">
+      <section className="border-t border-hairline px-5 py-16 md:px-6 md:py-24">
         <div className="mx-auto max-w-4xl">
           <div className="mb-14 text-center">
             <span className="eyebrow">Questions &amp; answers</span>
-            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-4xl tracking-tight text-ink md:text-[2.75rem]">
+            <h2 className="mx-auto mt-4 max-w-2xl font-serif text-3xl tracking-tight text-ink sm:text-4xl md:text-[2.75rem]">
               Frequently asked questions
             </h2>
             <p className="mx-auto mt-4 max-w-2xl leading-relaxed text-muted">
@@ -196,7 +196,7 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-hairline px-6 py-14">
+      <footer className="border-t border-hairline px-5 py-12 md:px-6 md:py-14">
         <div className="mx-auto max-w-7xl text-center">
           <h3 className="font-serif text-2xl italic text-ink">Text Compare Pro</h3>
           <p className="mt-2 text-sm text-muted">

--- a/components/LineDiffDisplay.tsx
+++ b/components/LineDiffDisplay.tsx
@@ -192,7 +192,7 @@ export default function LineDiffDisplay({
   };
 
   return (
-    <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 xl:grid-cols-2">
+    <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-2">
       {renderPanel('left')}
       {renderPanel('right')}
     </div>

--- a/components/ScrollIndicator.tsx
+++ b/components/ScrollIndicator.tsx
@@ -43,7 +43,7 @@ export default function ScrollIndicator({
 
   return (
     <div
-      className="pointer-events-none fixed bottom-12 right-2 top-12 z-30 w-[3px] rounded-full"
+      className="pointer-events-none fixed bottom-12 right-2 top-12 z-30 hidden w-[3px] rounded-full sm:block"
       style={{ background: 'var(--hairline)' }}
     >
       {diffPositions.map((pos, index) => (

--- a/components/TextCompare.tsx
+++ b/components/TextCompare.tsx
@@ -334,7 +334,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
 
       {/* Input Section */}
       <div className="mb-4 px-6">
-        <div className="relative mx-auto grid max-w-7xl grid-cols-1 gap-5 md:grid-cols-2">
+        <div className="relative grid w-full grid-cols-1 gap-5 md:grid-cols-2">
           {renderEditor(1)}
 
           {/* Swap texts */}
@@ -358,7 +358,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.25 }}
-          className="mx-auto mt-5 max-w-7xl"
+          className="mt-5 w-full"
         >
           <div className="card rounded-2xl px-4 py-3.5 md:px-5">
             <div className="flex flex-wrap items-center gap-3">
@@ -511,7 +511,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             exit={{ opacity: 0, y: 20 }}
             className="min-h-0 flex-1 px-6 pb-6"
           >
-            <div className="mx-auto flex h-full max-w-7xl flex-col">
+            <div className="flex h-full w-full flex-col">
               {/* Stats Bar */}
               <div ref={statsBarRef} className="card mb-4 shrink-0 rounded-2xl px-4 py-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">

--- a/components/TextCompare.tsx
+++ b/components/TextCompare.tsx
@@ -255,7 +255,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
         transition={{ delay: isOriginal ? 0.15 : 0.2 }}
         className="min-w-0"
       >
-        <div className="card editor-card flex h-64 flex-col overflow-hidden rounded-2xl">
+        <div className="card editor-card flex h-64 flex-col overflow-hidden rounded-2xl md:h-72">
           <div className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-2.5">
             <div className="flex items-center gap-2.5">
               <span
@@ -302,7 +302,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
     >
       {/* Header */}
       {!isFullscreen && (
-        <header className="px-6 pb-10 pt-14 text-center md:pt-20">
+        <header className="px-5 pb-8 pt-12 text-center sm:pb-10 sm:pt-14 md:pt-20">
           <motion.div
             initial={{ opacity: 0, y: -12 }}
             animate={{ opacity: 1, y: 0 }}
@@ -314,7 +314,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             initial={{ opacity: 0, y: -16 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.05 }}
-            className="mx-auto mt-5 max-w-3xl font-serif text-5xl font-medium tracking-tight text-ink md:text-[4.25rem] md:leading-[1.05]"
+            className="mx-auto mt-5 max-w-3xl font-serif text-4xl font-medium tracking-tight text-ink sm:text-5xl md:text-[4.25rem] md:leading-[1.05]"
           >
             Text Compare <em className="italic">Pro</em>
           </motion.h1>
@@ -322,7 +322,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.1 }}
-            className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-muted md:text-lg"
+            className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-muted sm:mt-5 sm:text-base md:text-lg"
           >
             The editorial-grade diff for prose and code. Find every{' '}
             <del className="demo-del">chnage</del>{' '}
@@ -333,20 +333,23 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
       )}
 
       {/* Input Section */}
-      <div className="mb-4 px-6">
-        <div className="relative grid w-full grid-cols-1 gap-5 md:grid-cols-2">
+      <div className="mb-4 px-3 sm:px-4 lg:px-6">
+        <div className="relative grid w-full grid-cols-1 gap-4 md:grid-cols-2 md:gap-5">
           {renderEditor(1)}
 
-          {/* Swap texts */}
-          <div className="absolute left-1/2 top-1/2 z-10 hidden -translate-x-1/2 -translate-y-1/2 md:block">
+          {/* Swap texts — sits between the editors: horizontally on desktop,
+              vertically when they stack on mobile */}
+          <div className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
             <motion.button
-              whileHover={{ scale: 1.08, rotate: 180 }}
+              whileHover={{ scale: 1.1 }}
               whileTap={{ scale: 0.92 }}
               onClick={handleSwap}
               title="Swap texts"
               className="card flex h-10 w-10 items-center justify-center rounded-full text-muted transition-colors hover:text-ink"
             >
-              <ArrowLeftRight size={15} />
+              <span className="block rotate-90 transition-transform md:rotate-0">
+                <ArrowLeftRight size={15} />
+              </span>
             </motion.button>
           </div>
 
@@ -360,8 +363,8 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
           transition={{ delay: 0.25 }}
           className="mt-5 w-full"
         >
-          <div className="card rounded-2xl px-4 py-3.5 md:px-5">
-            <div className="flex flex-wrap items-center gap-3">
+          <div className="card rounded-2xl px-3 py-3 sm:px-4 md:px-5 md:py-3.5">
+            <div className="flex flex-wrap items-center gap-2.5 md:gap-3">
               {/* Format Selector */}
               <label className="field" title="Source format">
                 <FileCode2 size={14} className="shrink-0 text-muted" />
@@ -412,7 +415,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
                 Ignore whitespace
               </label>
 
-              <div className="ml-auto flex items-center gap-2">
+              <div className="flex w-full items-center gap-2 md:ml-auto md:w-auto">
                 <motion.button
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
@@ -437,7 +440,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
                   whileHover={{ scale: 1.03 }}
                   whileTap={{ scale: 0.97 }}
                   onClick={handleCompare}
-                  className="btn-primary"
+                  className="btn-primary flex-1 md:flex-initial"
                 >
                   <GitCompare size={15} />
                   Compare
@@ -450,7 +453,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
 
       {/* Floating navigator - shows when the stats bar scrolls away */}
       {showDiff && diffResult && isScrolled && (
-        <div className="fixed right-5 top-1/2 z-50 -translate-y-1/2">
+        <div className="fixed right-2 top-1/2 z-50 -translate-y-1/2 sm:right-5">
           <motion.div
             initial={{ opacity: 0, x: 16 }}
             animate={{ opacity: 1, x: 0 }}
@@ -509,11 +512,11 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
-            className="min-h-0 flex-1 px-6 pb-6"
+            className="min-h-0 flex-1 px-3 pb-4 sm:px-4 md:pb-6 lg:px-6"
           >
             <div className="flex h-full w-full flex-col">
               {/* Stats Bar */}
-              <div ref={statsBarRef} className="card mb-4 shrink-0 rounded-2xl px-4 py-3">
+              <div ref={statsBarRef} className="card mb-4 shrink-0 rounded-2xl px-3 py-2.5 sm:px-4 sm:py-3">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="flex flex-wrap items-center gap-2">
                     {diffResult.stats.total === 0 ? (
@@ -606,7 +609,7 @@ export default function TextCompare({ onDiffToggle }: TextCompareProps = {}) {
             exit={{ opacity: 0, scale: 0.8 }}
             transition={{ duration: 0.2 }}
             onClick={scrollToTop}
-            className="btn-primary fixed bottom-8 right-8 z-40 !h-12 !w-12 !p-0"
+            className="btn-primary fixed bottom-5 right-5 z-40 !h-11 !w-11 !p-0 sm:bottom-8 sm:right-8 sm:!h-12 sm:!w-12"
             whileHover={{ scale: 1.08 }}
             whileTap={{ scale: 0.92 }}
             title="Back to top"


### PR DESCRIPTION
## Overview

Makes the whole page adaptive across devices — proper mobile support, and at every viewport size the four boxes (two editors + two diff panes) get as much width and visible content as possible.

> **Note:** this branch builds on #6 (full-width tool layout) and includes its commit. Merge #6 first and this PR shrinks to just the responsive work — or merge this one directly to get both.

## Changes

**Mobile (< 640px)**
- Slimmer diff gutter and +/− signs so the code itself gets the width (gutter number column 46px → 34px)
- Zero horizontal page overflow at 375/390px (verified)
- Hero title, tagline, and section headings scale down; tighter paddings throughout
- Scroll indicator hidden; floating navigator and scroll-to-top pulled closer to the edge
- Swap button now visible on mobile too — rotated vertical, sitting between the stacked editors

**Toolbar**
- Diff-mode segmented control pans horizontally when it cannot fit instead of breaking the layout
- Compare button stretches full-width below `md` for an easy touch target

**More visible content at every size**
- Tool-area side padding steps down on small screens (`px-3 / px-4 / px-6`)
- Editors grow taller on desktop (`h-64 → md:h-72`)
- Diff panes go side-by-side from `lg`, so 1280px laptops get the two-column comparison

## Verified (Playwright, real browser)

| Viewport | Result |
|---|---|
| 375 / 390px | no overflow, panes full-width stacked, gutter 34px, Compare spans toolbar, swap between editors |
| 768px | no overflow, panes 734px stacked |
| 1280px | side-by-side, rows aligned |
| 1920px | side-by-side 926px each, rows aligned |

Row alignment, sticky gutter, and synchronized scrolling re-verified after the changes; `next build` and lint clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSzKjbfT5WAdioPaM5hYuB)_