### PR TITLE
Add Web.Cafe WeChat QR login skill with session persistence

### DIFF
--- a/.claude/skills/webcafe-login/SKILL.md
+++ b/.claude/skills/webcafe-login/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: webcafe-login
+description: >-
+  Log in to Web.Cafe (new.web.cafe, "哥飞的朋友们") via personal-WeChat QR scan and save a
+  reusable session, then read member/paid (VIP) articles. Use when the user wants to log
+  into new.web.cafe / web.cafe, "扫码登录" there, or read its paid / VIP / member-only content.
+---
+
+# Web.Cafe WeChat-QR Login
+
+Logs into `new.web.cafe` using the **个人微信登录** (personal-WeChat) QR flow and saves a
+reusable session. Pure `curl` + Node — **no browser / Chromium needed**, so it is fast to
+set up in a fresh container.
+
+Let `SKILL` = the directory containing this `SKILL.md`. Runtime files are written to
+`WEBCAFE_WORKDIR` (default `/tmp/webcafe`); call it `WORKDIR` below.
+
+## When to use
+- The user asks to log into new.web.cafe / web.cafe, or to "扫码登录".
+- The user wants to read paid / VIP / member-only articles there.
+
+## How it works (reverse-engineered Auth.js / NextAuth flow)
+1. `GET /api/auth/csrf` → `csrfToken` (+ csrf cookie saved in the jar)
+2. `GET /api/auth/generatePersonalWechatLoginQRCode?callbackUrl=%2F&origin=https://new.web.cafe`
+   → `{ token, qrcode_url }`  (qrcode_url is a PNG encoding `…/auth/personalWechatLogin/<token>`)
+3. User scans `qrcode_url` with WeChat and taps **确认登录**
+4. Poll `GET /api/auth/checkPersonalWechatLogin?token=<token>` → `{ loggedIn, openid, msg }`
+5. `POST /api/auth/callback/personal-wechat`  (form: `csrfToken`, `callbackUrl`,
+   **`code=<openid>`**, `json=true`) → sets `__Secure-authjs.session-token`
+6. `GET /api/auth/session` → user object incl. `is_vip`
+
+> KEY GOTCHAS (learned the hard way — don't rediscover them):
+> - The credential field is **`code`**, and its value is the **`openid`** from step 4.
+>   The site's frontend literally does `signIn("personal-wechat", { code: decodeURIComponent(openid) })`.
+>   Sending `token`/`openid` instead → `error=CredentialsSignin`.
+> - The container egresses through a **TLS-intercepting proxy**, so `curl` needs `-k`
+>   (and a real browser would need `ignoreHTTPSErrors` / `--ignore-certificate-errors`).
+> - The displayed QR can client-side-expire before the user scans. The script
+>   auto-regenerates it and remembers **every** token it issued, so a QR already shown
+>   to the user still completes login.
+
+## Agent steps to drive it
+1. Start the login in the **background** (it blocks while polling for the scan):
+   ```bash
+   node "$SKILL/scripts/wechat_login.js"          # WEBCAFE_WORKDIR / WEBCAFE_TIMEOUT (sec) optional
+   ```
+2. Poll `"$WORKDIR/status.json"` until `state == "waiting"` and `"$WORKDIR/qr.png"` exists.
+3. **Send the QR to the user**: `SendUserFile "$WORKDIR/qr.png"`, and tell them:
+   微信 →「扫一扫」→ 扫码 → 点「确认登录」(scan promptly).
+4. Keep polling `status.json`:
+   - if `qr_version` increased → the QR refreshed, re-send `qr.png`;
+   - when `state == "ok"` → success; `status.json.user` has `name` + `is_vip`;
+   - `state == "timeout" | "error"` → report and offer to re-run.
+5. The reusable session is saved at `"$WORKDIR/session.jar"` (and the user object at
+   `"$WORKDIR/session.json"`).
+
+## Reading content after login
+```bash
+node "$SKILL/scripts/wc_fetch.js" /experience/<id>      # → clean readable text
+node "$SKILL/scripts/wc_fetch.js" <full-url> --html      # → raw HTML
+```
+Member/paid article bodies are server-rendered into the authenticated HTML, so the saved
+cookie jar is all that's required to read them.
+
+## Notes
+- Session lives **only** in this ephemeral container under `WORKDIR`; it expires
+  (~30 days server-side) and is **never committed**. Add `/tmp/webcafe` is outside the repo.
+- Next time: invoke this skill and scan once — that's it.

--- a/.claude/skills/webcafe-login/scripts/wc_fetch.js
+++ b/.claude/skills/webcafe-login/scripts/wc_fetch.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/*
+ * Fetch any new.web.cafe URL using the session saved by wechat_login.js and print it.
+ * Member/paid article bodies are server-rendered into the authenticated HTML, so the
+ * saved cookie jar is enough to read them.
+ *
+ * Usage:
+ *   node wc_fetch.js /experience/<id>        # -> clean readable text (default)
+ *   node wc_fetch.js <full-url>              # path or absolute URL both work
+ *   node wc_fetch.js <url> --html            # -> raw HTML
+ *
+ * Env: WEBCAFE_WORKDIR (default /tmp/webcafe) — where session.jar lives.
+ */
+'use strict';
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const BASE = 'https://new.web.cafe';
+const WORKDIR = process.env.WEBCAFE_WORKDIR || '/tmp/webcafe';
+const JAR = path.join(WORKDIR, 'session.jar');
+
+const arg = process.argv[2];
+if (!arg) { console.error('usage: node wc_fetch.js <url-or-path> [--html]'); process.exit(2); }
+if (!fs.existsSync(JAR)) { console.error('No session jar at ' + JAR + ' — run wechat_login.js first.'); process.exit(3); }
+
+const url = /^https?:\/\//.test(arg) ? arg : BASE + (arg.startsWith('/') ? arg : '/' + arg);
+const wantHtml = process.argv.includes('--html');
+
+const html = execFileSync('curl', ['-sS', '-k', '-m', '25', '-b', JAR, url], {
+  encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+});
+
+if (wantHtml) { process.stdout.write(html); process.exit(0); }
+
+let h = html
+  .replace(/<script[\s\S]*?<\/script>/gi, ' ')   // drop scripts (also the duplicated RSC flight JSON)
+  .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+  .replace(/<\/(p|div|li|h[1-6]|tr|section|article|ul|ol|blockquote)>/gi, '\n')
+  .replace(/<br\s*\/?>/gi, '\n')
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#x27;/g, "'")
+  .replace(/&#39;/g, "'").replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&nbsp;/g, ' ')
+  .replace(/[ \t]+/g, ' ')
+  .replace(/[ \t]*\n[ \t]*/g, '\n')
+  .replace(/\n{3,}/g, '\n\n')
+  .trim();
+
+process.stdout.write(h + '\n');

--- a/.claude/skills/webcafe-login/scripts/wechat_login.js
+++ b/.claude/skills/webcafe-login/scripts/wechat_login.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/*
+ * Web.Cafe (new.web.cafe) — personal-WeChat QR login -> saves a reusable session.
+ * Pure curl + Node, no browser.
+ *
+ * Flow (Auth.js / NextAuth):
+ *   GET  /api/auth/csrf                                   -> csrfToken (+ csrf cookie)
+ *   GET  /api/auth/generatePersonalWechatLoginQRCode      -> { token, qrcode_url }
+ *        ?callbackUrl=%2F&origin=https://new.web.cafe
+ *   (user scans qrcode_url with WeChat, taps 确认登录)
+ *   GET  /api/auth/checkPersonalWechatLogin?token=TOKEN   -> { loggedIn, openid, msg }
+ *   POST /api/auth/callback/personal-wechat               -> sets session cookie
+ *        form: csrfToken, callbackUrl, code=<openid>, json=true     (field is `code`)
+ *   GET  /api/auth/session                                -> { user: { ..., is_vip } }
+ *
+ * Output files in WORKDIR (default /tmp/webcafe):
+ *   qr.png         the QR image to send to the user
+ *   status.json    { state: starting|waiting|completing|ok|timeout|error, qr_version, token, user, msg }
+ *   session.jar    curl cookie jar with the session   (use: curl -b session.jar ...)
+ *   session.json   the logged-in user object
+ */
+'use strict';
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const BASE = 'https://new.web.cafe';
+const WORKDIR = process.env.WEBCAFE_WORKDIR || '/tmp/webcafe';
+const JAR = path.join(WORKDIR, 'session.jar');
+const QR = path.join(WORKDIR, 'qr.png');
+const STATUS = path.join(WORKDIR, 'status.json');
+const SESSION = path.join(WORKDIR, 'session.json');
+const TIMEOUT_MS = (Number(process.env.WEBCAFE_TIMEOUT) || 300) * 1000;
+const REFRESH_MS = 110 * 1000; // regenerate QR if still waiting this long
+
+fs.mkdirSync(WORKDIR, { recursive: true });
+
+// curl wrapper. -k tolerates this environment's TLS-intercepting egress proxy.
+function curl(args) {
+  return execFileSync('curl', ['-sS', '-k', '-m', '25', ...args], {
+    encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+  });
+}
+function curlJSON(args) {
+  const out = curl(args);
+  try { return JSON.parse(out); } catch (e) { return { __raw: out, __parseError: true }; }
+}
+
+let status = { state: 'starting', qr_version: 0, token: null, msg: '', ts: Date.now() };
+function writeStatus(extra) {
+  status = { ...status, ...extra, ts: Date.now() };
+  fs.writeFileSync(STATUS + '.tmp', JSON.stringify(status, null, 2));
+  fs.renameSync(STATUS + '.tmp', STATUS);
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let csrfToken = null;
+function getCsrf() {
+  const j = curlJSON(['-c', JAR, `${BASE}/api/auth/csrf`]);
+  csrfToken = j && j.csrfToken;
+  if (!csrfToken) throw new Error('failed to get csrfToken: ' + JSON.stringify(j).slice(0, 200));
+}
+function genQR() {
+  const url = `${BASE}/api/auth/generatePersonalWechatLoginQRCode?callbackUrl=%2F&origin=${encodeURIComponent(BASE)}`;
+  const j = curlJSON(['-b', JAR, '-c', JAR, url]);
+  if (!j || !j.qrcode_url || !j.token) throw new Error('generate QR failed: ' + JSON.stringify(j).slice(0, 200));
+  curl(['-b', JAR, '-o', QR, j.qrcode_url]); // download the PNG
+  status.qr_version = (status.qr_version || 0) + 1;
+  return j.token;
+}
+function check(token) {
+  return curlJSON(['-b', JAR, `${BASE}/api/auth/checkPersonalWechatLogin?token=${encodeURIComponent(token)}`]);
+}
+function complete(openid) {
+  let code = openid;
+  try { code = decodeURIComponent(openid); } catch (e) { /* openid is raw base64; keep as-is */ }
+  curl([
+    '-b', JAR, '-c', JAR, '-o', path.join(WORKDIR, 'callback.out'),
+    '-X', 'POST', `${BASE}/api/auth/callback/personal-wechat`,
+    '-H', 'Content-Type: application/x-www-form-urlencoded',
+    '--data-urlencode', `csrfToken=${csrfToken}`,
+    '--data-urlencode', `callbackUrl=${BASE}/`,
+    '--data-urlencode', `code=${code}`,
+    '--data-urlencode', 'json=true',
+  ]);
+  return curlJSON(['-b', JAR, `${BASE}/api/auth/session`]);
+}
+
+(async () => {
+  try {
+    fs.rmSync(JAR, { force: true });
+    writeStatus({ state: 'starting', msg: '初始化' });
+    getCsrf();
+
+    const tokens = [genQR()];           // remember every token we issue (handles QR refresh races)
+    let qrBornAt = Date.now();
+    writeStatus({ state: 'waiting', token: tokens[tokens.length - 1], qr: QR, msg: '等待扫码' });
+
+    const deadline = Date.now() + TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      for (const t of tokens) {
+        const r = check(t);
+        if (r && r.loggedIn === true && r.openid) {
+          writeStatus({ state: 'completing', msg: '扫码成功，正在换取会话' });
+          const sess = complete(r.openid);
+          if (sess && sess.user) {
+            fs.writeFileSync(SESSION, JSON.stringify(sess, null, 2));
+            writeStatus({ state: 'ok', user: sess.user, msg: '登录成功' });
+            console.log('OK: logged in as', sess.user.name, '| vip=', sess.user.is_vip);
+            return;
+          }
+          writeStatus({ state: 'error', msg: 'callback 未换到会话(检查 code 字段/ token 是否过期)' });
+          return;
+        }
+      }
+      if (Date.now() - qrBornAt > REFRESH_MS) {
+        tokens.push(genQR());
+        if (tokens.length > 4) tokens.shift();
+        qrBornAt = Date.now();
+        writeStatus({ state: 'waiting', token: tokens[tokens.length - 1], qr: QR, msg: '二维码已刷新，请重扫' });
+      }
+      await sleep(2500);
+    }
+    writeStatus({ state: 'timeout', msg: '超时未完成扫码' });
+    process.exitCode = 1;
+  } catch (e) {
+    writeStatus({ state: 'error', msg: String(e && e.message) });
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
Add a new Claude skill for logging into Web.Cafe (new.web.cafe) via personal-WeChat QR code scanning and saving a reusable session. This enables reading member/paid content without requiring a browser.

## Key Changes
- **`wechat_login.js`**: Main login script that implements the reverse-engineered Auth.js/NextAuth flow
  - Obtains CSRF token and generates WeChat QR codes
  - Polls for user scan completion via `checkPersonalWechatLogin` endpoint
  - Auto-refreshes QR codes if they expire before scanning
  - Exchanges openid for authenticated session cookie
  - Saves session jar and user object for reuse
  - Configurable timeout and work directory via environment variables

- **`wc_fetch.js`**: Utility script to fetch Web.Cafe content using the saved session
  - Supports both path and full URL arguments
  - Outputs clean readable text by default (HTML stripping)
  - Optional `--html` flag for raw HTML output
  - Uses the persisted session jar for authenticated requests

- **`SKILL.md`**: Comprehensive documentation including
  - When and how to use the skill
  - Detailed reverse-engineered API flow with key gotchas
  - Step-by-step agent integration instructions
  - Notes on session lifecycle and limitations

## Notable Implementation Details
- Pure `curl` + Node.js (no browser/Chromium required) for fast container setup
- Handles TLS-intercepting egress proxies with `curl -k`
- Remembers all issued QR tokens to handle client-side expiration races
- Atomic status file writes via temp file + rename pattern
- Session persisted to `WEBCAFE_WORKDIR` (default `/tmp/webcafe`) for reuse across invocations

https://claude.ai/code/session_017j3GgQSjBsoEJrceuYMQZe